### PR TITLE
AWS: Set launch block device to 6,000 IOPS

### DIFF
--- a/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
@@ -259,7 +259,7 @@ source "amazon-ebs" "build_image" {
     volume_type = "${var.aws_volume_type}"
     volume_size = "${var.aws_volume_size}"
     delete_on_termination = "true"
-    iops = 4000
+    iops = 6000
     throughput = 1000
     encrypted = "false"
   }

--- a/images/ubuntu/templates/ubuntu-22.04.arm64.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.arm64.pkr.hcl
@@ -259,7 +259,7 @@ source "amazon-ebs" "build_image" {
     volume_type = "${var.aws_volume_type}"
     volume_size = "${var.aws_volume_size}"
     delete_on_termination = "true"
-    iops = 4000
+    iops = 6000
     throughput = 1000
     encrypted = "false"
   }

--- a/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
@@ -259,7 +259,7 @@ source "amazon-ebs" "build_image" {
     volume_type = "${var.aws_volume_type}"
     volume_size = "${var.aws_volume_size}"
     delete_on_termination = "true"
-    iops = 4000
+    iops = 6000
     throughput = 1000
     encrypted = "false"
   }

--- a/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
@@ -246,7 +246,7 @@ source "amazon-ebs" "build_image" {
     volume_type = "${var.aws_volume_type}"
     volume_size = "${var.aws_volume_size}"
     delete_on_termination = "true"
-    iops = 4000
+    iops = 6000
     throughput = 1000
     encrypted = "false"
   }


### PR DESCRIPTION
We've found that 4,000 is not quite enough. Our current CI system uses 6,000 so let's keep aligned.