### PR TITLE
Bump machine types to match standard ubuntu options

### DIFF
--- a/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
@@ -234,7 +234,7 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type                   = "hvm"
   ami_groups                                = var.aws_private_ami ? [] : ["all"]
   ebs_optimized                             = true
-  spot_instance_types                       = ["t3.xlarge"]
+  spot_instance_types                       = ["m7i.xlarge"]
   spot_price                                = "1.00"
   region                                    = "${var.aws_region}"
   ssh_username                              = "ubuntu"

--- a/images/ubuntu/templates/ubuntu-22.04.arm64.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.arm64.pkr.hcl
@@ -234,7 +234,7 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type                   = "hvm"
   ami_groups                                = var.aws_private_ami ? [] : ["all"]
   ebs_optimized                             = true
-  spot_instance_types                       = ["t4g.xlarge"]
+  spot_instance_types                       = ["m7g.xlarge"]
   spot_price                                = "1.00"
   region                                    = "${var.aws_region}"
   ssh_username                              = "ubuntu"

--- a/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
@@ -234,7 +234,7 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type                   = "hvm"
   ami_groups                                = var.aws_private_ami ? [] : ["all"]
   ebs_optimized                             = true
-  spot_instance_types                       = ["t3.xlarge"]
+  spot_instance_types                       = ["m7i.xlarge"]
   spot_price                                = "1.00"
   region                                    = "${var.aws_region}"
   ssh_username                              = "ubuntu"

--- a/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
@@ -220,7 +220,7 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type                   = "hvm"
   ami_groups                                = var.aws_private_ami ? [] : ["all"]
   ebs_optimized                             = true
-  spot_instance_types                       = ["t3.xlarge"]
+  spot_instance_types                       = ["m7i.xlarge"]
   spot_price                                = "1.00"
   region                                    = "${var.aws_region}"
   ssh_username                              = "ubuntu"


### PR DESCRIPTION
This bumps the machine types to match the standard machine options used [here](https://github.com/grafana/deployment_tools/blob/master/terraform/projects/aws/github-runners-prod/templates/runner-configs/ubuntu-x64.yaml). 