### PR TITLE
Fix issue detecting prod releases on build-and-publish workflow

### DIFF
--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -8,7 +8,22 @@ permissions:
   id-token: write
 
 jobs:
+  get-branch:
+    runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.branch.outputs.value }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+      - name: Determine the branch that contains the tag
+        id: branch
+        run: |
+          branch=$(git branch -r --contains ${{ github.sha }} | grep -v 'HEAD' | head -n 1 | sed 's/ *origin\///')
+          echo "value=$branch" >> $GITHUB_OUTPUT
+
   build:
+    needs: get-branch
     runs-on: ubuntu-latest
 
     env:
@@ -24,8 +39,8 @@ jobs:
           - images/ubuntu/templates/ubuntu-22.04.pkr.hcl
           - images/ubuntu/templates/ubuntu-22.04.arm64.pkr.hcl
         prodRelease:
-          # if we are tagging main, the tag starts with v and doesn't contain an hyphen, this is a prod release
-          - ${{ github.base_ref == 'main' && !contains(github.ref_name, '-') }}
+          # if we are tagging main and the tag doesn't contain an hyphen, this is a prod release
+          - ${{ needs.get-branch.outputs.branch == 'main' && !contains(github.ref_name, '-') }}
         exclude:
           # exclude releasing to prod if this is not a prod release
           - prodRelease: false


### PR DESCRIPTION
There was an issue with the workflow, it was using `github.base_ref` which was fine while implemented in a pull request, however this context variable is not set outside of pull request events, so we need to find a different way to find it.