### PR TITLE
Replace get-branch job for check-if-main

### DIFF
--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -8,7 +8,7 @@ permissions:
   id-token: write
 
 jobs:
-  check-main:
+  check-if-main:
     runs-on: ubuntu-latest
     outputs:
       is-main: ${{ steps.is_main.outputs.value }}
@@ -25,7 +25,7 @@ jobs:
           echo "value=$is_main" >> "${GITHUB_OUTPUT}"
 
   build:
-    needs: check-main
+    needs: check-if-main
     runs-on: ubuntu-latest
 
     env:
@@ -42,7 +42,7 @@ jobs:
           - images/ubuntu/templates/ubuntu-22.04.arm64.pkr.hcl
         prodRelease:
           # if we are tagging main and the tag doesn't contain an hyphen, this is a prod release
-          - ${{ needs.check-main.outputs.is-main == 'true' && !contains(github.ref_name, '-') }}
+          - ${{ needs.check-if-main.outputs.is-main == 'true' && !contains(github.ref_name, '-') }}
         exclude:
           # exclude releasing to prod if this is not a prod release
           - prodRelease: false

--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -13,12 +13,18 @@ jobs:
     outputs:
       is-main: ${{ steps.is_main.outputs.value }}
     steps:
+      - name: Error on non-tag events
+        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          echo "This workflow can only be triggered by tag events."
+          exit 1
+
       - name: Checkout main branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: main
 
-      - name: Check if main branch contains the commit
+      - name: Check if main branch contains the tagged commit
         id: is_main
         run: |
           is_main=$(git branch -r --contains ${{ github.sha }} | grep -q 'main' && echo true || echo false)

--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -8,22 +8,24 @@ permissions:
   id-token: write
 
 jobs:
-  get-branch:
+  check-main:
     runs-on: ubuntu-latest
     outputs:
-      branch: ${{ steps.branch.outputs.value }}
+      is-main: ${{ steps.is_main.outputs.value }}
     steps:
-      - name: Checkout repository
+      - name: Checkout main branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          ref: main
 
-      - name: Determine the branch that contains the tag
-        id: branch
+      - name: Check if main branch contains the commit
+        id: is_main
         run: |
-          branch=$(git branch -r --contains ${{ github.sha }} | grep -v 'HEAD' | head -n 1 | sed 's/ *origin\///')
-          echo "value=$branch" >> $GITHUB_OUTPUT
+          is_main=$(git branch -r --contains ${{ github.sha }} | grep -q 'main' && echo true || echo false)
+          echo "value=$is_main" >> "${GITHUB_OUTPUT}"
 
   build:
-    needs: get-branch
+    needs: check-main
     runs-on: ubuntu-latest
 
     env:
@@ -40,7 +42,7 @@ jobs:
           - images/ubuntu/templates/ubuntu-22.04.arm64.pkr.hcl
         prodRelease:
           # if we are tagging main and the tag doesn't contain an hyphen, this is a prod release
-          - ${{ needs.get-branch.outputs.branch == 'main' && !contains(github.ref_name, '-') }}
+          - ${{ needs.check-main.outputs.is-main == 'true' && !contains(github.ref_name, '-') }}
         exclude:
           # exclude releasing to prod if this is not a prod release
           - prodRelease: false

--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -9,16 +9,11 @@ permissions:
 
 jobs:
   check-if-main:
+    if: ${{ startsWith(github.ref, 'refs/tags/') }}
     runs-on: ubuntu-latest
     outputs:
       is-main: ${{ steps.is_main.outputs.value }}
     steps:
-      - name: Error on non-tag events
-        if: ${{ !startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          echo "This workflow can only be triggered by tag events."
-          exit 1
-
       - name: Checkout main branch
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:

--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Check if main branch contains the tagged commit
         id: is_main
         run: |
-          is_main=$(git branch -r --contains ${{ github.sha }} | grep -q 'main' && echo true || echo false)
+          is_main=$([ -n "$(git branch -r --contains ${{ github.sha }} origin/main)" ] && echo true || echo false)
           echo "value=$is_main" >> "${GITHUB_OUTPUT}"
 
   build:


### PR DESCRIPTION
The step `get-branch` was using `branch=$(git branch -r --contains ${{ github.sha }} | grep -v 'HEAD' | head -n 1 | sed 's/ *origin\///')` to get the current branch for the tag, however if more than one branch contains the tag this could cause issues since `head -n 1` would return based on alphabetical order.

I replaced the job for a more straighforward approach that checks if main contains the sha, thats all we used the get-branch job for, just to tell if we need to do a prod release.