### PR TITLE
Fix dotnet version regex on software report

### DIFF
--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -247,7 +247,7 @@ $browsersTools.AddHeader("Environment variables").AddTable($(Build-BrowserWebdri
 
 # .NET Tools
 $netCoreTools = $installedSoftware.AddHeader(".NET Tools")
-$netCoreTools.AddToolVersionsListInline(".NET Core SDK", $(Get-DotNetCoreSdkVersions), "^\d+\.\d+\.\d")
+$netCoreTools.AddToolVersionsListInline(".NET Core SDK", $(Get-DotNetCoreSdkVersions), "^\d+\.\d+\.\d+")
 $netCoreTools.AddNodes($(Get-DotnetTools))
 
 # Databases


### PR DESCRIPTION
There has been an issue after the most recent update from upstream: https://github.com/grafana/runner-images/actions/runs/11019481772/job/30602150497

The update did fix the installation of a few packages that were broken, however there's an issue on the software report, since the regex only considers the first digit of samver, both versions 8.0.401 and 8.0.402 return as the same version 8.0.4, this adjusts the regex so all versions are considered on the report.