### PR TITLE
Fix draft release check on packer-build-and-publish.yml workflow

### DIFF
--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -149,7 +149,9 @@ jobs:
 
   publish:
     runs-on: ubuntu-latest
-    needs: build
+    needs:
+      - check-if-main
+      - build
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -236,6 +238,6 @@ jobs:
           files: artifacts/**/*.json
           body: |
             Release ${{ github.ref_name }} from workflow [#${{ github.run_id}}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          draft: ${{ github.base_ref != 'main' || contains(github.ref_name, '-') }}
+          draft: ${{ needs.check-if-main.outputs.is-main != 'true' || contains(github.ref_name, '-') }}
           make_latest: ${{ !(github.base_ref != 'main' || contains(github.ref_name, '-')) && steps.is_latest.outputs.value }}
           generate_release_notes: true


### PR DESCRIPTION
Current check is using base_ref which is only present on pull_request events, this changes it so it considers the result of check-if-main instead of using base_ref to check if the tag is on main.

With this change if the tag is a prod release the release will be created normally, if it's a dev release it will be created as a draft.

Currently prod releases are created as drafts and need to be manually published, they should be automatically published if it's a prod release.