### PR TITLE
Fix tool architecture mismatch on toolset configuration

### DIFF
--- a/images/ubuntu/scripts/build/Configure-Toolset.ps1
+++ b/images/ubuntu/scripts/build/Configure-Toolset.ps1
@@ -29,6 +29,36 @@ function Get-TCToolVersionPath {
     return $installationDir
 }
 
+function Get-TCAssetArchitecture {
+    param(
+        [Parameter(Mandatory)]
+        [PSCustomObject[]] $Assets,
+        [Parameter(Mandatory)]
+        [PSCustomObject] $Tool,
+        [Parameter(Mandatory)]
+        [string] $ToolVersion
+    )
+
+    if ($arch -eq "amd64") {
+        $assetArchs = @("x64", "amd64")
+    }
+
+    if ($arch -eq "arm64") {
+        $assetArchs = @("arm64", "aarch64")
+    }
+
+    $asset = $Assets | Where-Object version -like $ToolVersion `
+        | Select-Object -ExpandProperty files `
+        | Where-Object { ($_.platform -eq $Tool.platform) -and ($_.platform_version -eq $Tool.platform_version) -and ($assetArchs -contains $_.arch) } `
+        | Select-Object -First 1
+
+    if ([string]::IsNullOrEmpty($asset.arch)) {
+        return $arch
+    } else {
+        return $asset.arch
+    }
+}
+
 function Add-GlobalEnvironmentVariable {
     param(
         [Parameter(Mandatory)]
@@ -45,11 +75,10 @@ function Add-GlobalEnvironmentVariable {
 $ErrorActionPreference = "Stop"
 
 Write-Host "Configure toolcache tools environment..."
-$toolEnvArch = ($arch -eq "arm64") ? "ARM64" : "X64"
 $toolEnvConfigs = @{
     go = @{
         command          = "ln -s {0}/bin/* /usr/bin/"
-        variableTemplate = "GOROOT_{0}_{1}_${toolEnvArch}"
+        variableTemplate = "GOROOT_{0}_{1}_{2}"
     }
 }
 
@@ -59,15 +88,23 @@ $tools = (Get-ToolsetContent).toolcache | Where-Object { $toolEnvConfigs.Keys -c
 foreach ($tool in $tools) {
     $toolEnvConfig = $toolEnvConfigs[$tool.name]
 
+    # If the tool has a url, get the versions manifest
+    if ($tool.url) {
+        $assets = Invoke-RestMethod $tool.url
+    }
+
     if (-not ([string]::IsNullOrEmpty($toolEnvConfig.variableTemplate))) {
         foreach ($toolVersion in $tool.versions) {
             Write-Host "Set $($tool.name) $toolVersion environment variable..."
-            $toolPath = Get-TCToolVersionPath -ToolName $tool.name -ToolVersion $toolVersion -ToolArchitecture $arch
+            $toolArch = Get-TCAssetArchitecture -Assets $assets -Tool $tool -ToolVersion $toolVersion
+            $toolPath = Get-TCToolVersionPath -ToolName $tool.name -ToolVersion $toolVersion -ToolArchitecture $toolArch
             if (-not $toolPath) {
                 Write-Host "Tool $($tool.name) $toolVersion not found in toolcache for $arch"
                 continue
             }
-            $envVariableName = $toolEnvConfig.variableTemplate -f $toolVersion.split(".")
+
+            $versionParts = $toolVersion.split(".")
+            $envVariableName = $toolEnvConfig.variableTemplate -f $versionParts[0], $versionParts[1], $toolArch.ToUpper()
 
             Add-GlobalEnvironmentVariable -Name $envVariableName -Value $toolPath
         }
@@ -75,7 +112,8 @@ foreach ($tool in $tools) {
 
     # Invoke command and add env variable for the default tool version
     if (-not ([string]::IsNullOrEmpty($tool.default))) {
-        $toolDefaultPath = Get-TCToolVersionPath -ToolName $tool.name -ToolVersion $tool.default -ToolArchitecture $arch
+        $toolArch = Get-TCAssetArchitecture -Assets $assets -Tool $tool -ToolVersion $tool.default || $arch
+        $toolDefaultPath = Get-TCToolVersionPath -ToolName $tool.name -ToolVersion $tool.default -ToolArchitecture $toolArch
         if (-not $toolDefaultPath) {
             Write-Host "Tool $($tool.name) $($tool.default) not found in toolcache for $arch"
             continue

--- a/images/ubuntu/scripts/build/Configure-Toolset.ps1
+++ b/images/ubuntu/scripts/build/Configure-Toolset.ps1
@@ -53,8 +53,10 @@ function Get-TCAssetArchitecture {
         | Select-Object -First 1
 
     if ([string]::IsNullOrEmpty($asset.arch)) {
+        Write-Host "Asset for $($tool.name) $toolVersion $($arch) not found in versions manifest"
         return $arch
     } else {
+        Write-Host "Asset for $($tool.name) $toolVersion $($arch) found in versions manifest using $($asset.arch)"
         return $asset.arch
     }
 }
@@ -90,6 +92,7 @@ foreach ($tool in $tools) {
 
     # If the tool has a url, get the versions manifest
     if ($tool.url) {
+        Write-Host "Retrieving assets for $($tool.name)..."
         $assets = Invoke-RestMethod $tool.url
     }
 


### PR DESCRIPTION
Fix https://github.com/grafana/deployment_tools/issues/177202

> In the [setup-argo shared action](https://github.com/grafana/shared-workflows/blob/main/actions/setup-argo/action.yaml#L34-L35), the Map OS and ARCH to Argo release artifact step fails because it relies on go to retrieve the os/arch:
> ```
> /opt/actions-runner/_work/_temp/d0e9b702-51ca-42d7-824c-60e76f09ec36.sh: 1: go: not found
> /opt/actions-runner/_work/_temp/d0e9b702-51ca-42d7-824c-60e76f09ec36.sh: 2: go: not found
> ```
> 
> This issue is only present on ubuntu-x64 self-hosted runners whereas arm runners are fine.
> 
> Noticed `GOROOT_1_22_X64=/opt/hostedtoolcache/go/1.22.3/amd64` exists in the output of printenv but when using `actions/setup-go`, it's `GOROOT='/opt/hostedtoolcache/go/1.22.3/x64'`
> 
> Example:
> ```
> Setup go version spec 1.22.3
> Found in cache @ /opt/hostedtoolcache/go/1.22.3/x64
> ```
> 
> I wonder if amd64 vs x64 is causing problems or just the env vars not getting set properly