### PR TITLE
Fix commits not being found on main branch

### DIFF
--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Check if main branch contains the tagged commit
         id: is_main
         run: |
+          git fetch origin main --depth=$((2**31 - 1)) # Fetch all commits from main
           is_main=$([ -n "$(git branch -r --contains ${{ github.sha }} origin/main)" ] && echo true || echo false)
           echo "value=$is_main" >> "${GITHUB_OUTPUT}"
 


### PR DESCRIPTION
Checkout all commits for main, otherwise it only checks the last commit.

This has been working so far because the tagged commit was always the last commit, this is not the case for v1.2.0 and that's why the tag is not copying images to prod or publishing the release.