### PR TITLE
Consider modified untracked files as artifacts on build-and-publish w…

### DIFF
--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -183,6 +183,7 @@ jobs:
       - name: Preapre artifacts
         id: artifacts
         run: |
+          git add -N .
           mkdir -p artifacts
           name=$(basename -s .pkr.hcl ${{ matrix.template }})
           readme=$(git diff --name-only -- '*.md')


### PR DESCRIPTION
Currently this impacts https://github.com/grafana/runner-images/pull/124 since the readmes for Ubuntu24-arm64 don't exist yet.