### PR TITLE
Fix failure to sync from upstream with workflow changes

### DIFF
--- a/.github/workflows/sync-upstream-change.yml
+++ b/.github/workflows/sync-upstream-change.yml
@@ -4,6 +4,11 @@ on:
   pull_request_review:
     types: [edited, submitted]
 
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write
+
 jobs:
   sync:
     runs-on: ubuntu-latest
@@ -12,11 +17,26 @@ jobs:
       github.event.review.state == 'changes_requested' &&
       github.event.review.body == 'bot change'
     steps:
+      - name: Retrieve secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            APP_ID=app:id
+            APP_PRIVATE_KEY=app:private-key
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.APP_PRIVATE_KEY }}
+
       - name: Checkout the repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Reset branch to main
         run: |

--- a/.github/workflows/sync-upstream-change.yml
+++ b/.github/workflows/sync-upstream-change.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         with:
           app-id: ${{ env.APP_ID }}
           private-key: ${{ env.APP_PRIVATE_KEY }}

--- a/.github/workflows/sync-upstream-create.yml
+++ b/.github/workflows/sync-upstream-create.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         with:
           app-id: ${{ env.APP_ID }}
           private-key: ${{ env.APP_PRIVATE_KEY }}

--- a/.github/workflows/sync-upstream-create.yml
+++ b/.github/workflows/sync-upstream-create.yml
@@ -8,16 +8,32 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     steps:
+      - name: Retrieve secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            APP_ID=app:id
+            APP_PRIVATE_KEY=app:private-key
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.APP_PRIVATE_KEY }}
+
       - name: Checkout the repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
           ref: main
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Create new branch from main
         run: |

--- a/.github/workflows/sync-upstream-merge.yml
+++ b/.github/workflows/sync-upstream-merge.yml
@@ -7,6 +7,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   sync:
@@ -16,11 +17,26 @@ jobs:
       github.event.review.state == 'approved' &&
       github.event.review.body == 'bot merge'
     steps:
+      - name: Retrieve secrets
+        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        with:
+          repo_secrets: |
+            APP_ID=app:id
+            APP_PRIVATE_KEY=app:private-key
+
+      - name: Generate a token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ env.APP_ID }}
+          private-key: ${{ env.APP_PRIVATE_KEY }}
+
       - name: Checkout the repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Configure Git
         run: |

--- a/.github/workflows/sync-upstream-merge.yml
+++ b/.github/workflows/sync-upstream-merge.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Generate a token
         id: generate-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
         with:
           app-id: ${{ env.APP_ID }}
           private-key: ${{ env.APP_PRIVATE_KEY }}


### PR DESCRIPTION
Apparently the sync from upstream workflow failed due to changes on a workflow file.

We had previously created a bot for this, but at some point it seemed like it was unnecessary, it seems it's time to use it now since the bot token will have permissions to modify workflows that workflows can't have.

https://github.com/grafana/runner-images/actions/runs/11621788250/job/32366162709