### PR TITLE
Fix regex and glob for build manifests on copy step

### DIFF
--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -295,7 +295,7 @@ jobs:
             "${{ github.api_url }}/repos/${{ github.repository }}/releases/${{ needs.publish.outputs.release_id }}/assets")
 
           # Filter assets matching the pattern and download each one
-          echo "$assets" | jq -r '.[] | select(.name | test("^build-manifest-.*\\.json$")) | "\(.id) \(.name)"' | while read -r asset_id asset_name; do
+          echo "$assets" | jq -r '.[] | select(.name | test(".*build-manifest\\.json$")) | "\(.id) \(.name)"' | while read -r asset_id asset_name; do
             echo "Downloading $asset_name (ID: $asset_id)"
             curl -L -H "Accept: application/octet-stream" \
               -H "Authorization: token ${{ github.token }}" \
@@ -313,7 +313,7 @@ jobs:
       - name: Share AMIs with Prod Account
         run: |
           PROD_ACCOUNT_ID="${{ env.PROD_ACCOUNT }}"
-          for file in build-manifest-*.json; do
+          for file in *build-manifest.json; do
             echo "Processing $file for sharing"
             builds_length=$(jq '.builds | length' "$file")
             for ((i=0; i<$builds_length; i++)); do
@@ -346,7 +346,7 @@ jobs:
 
       - name: Copy AMIs to Prod Account
         run: |
-          for file in build-manifest-*.json; do
+          for file in *build-manifest.json; do
             echo "Processing $file for copying"
             builds_length=$(jq '.builds | length' "$file")
             for ((i=0; i<$builds_length; i++)); do


### PR DESCRIPTION
Some changes form #124 renamed artifacts on releases, so the globs and regex checks on this step stopped working, this fixes that.

You can see the difference between the releases v1.2.0 and v2.0.0 on the artifacts:
https://github.com/grafana/runner-images/releases

The new naming approach makes it so all artifacts for a specific version and architecture are close together on the release.