### PR TITLE
Add m6i and m6g instance types as fallback for spot instances

### DIFF
--- a/images/ubuntu/scripts/build/install-kubernetes-tools.sh
+++ b/images/ubuntu/scripts/build/install-kubernetes-tools.sh
@@ -35,10 +35,11 @@ curl -fsSL https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
 
 # Temporarily pinning the version
 # Download minikube
-curl -fsSL -O https://storage.googleapis.com/minikube/releases/latest/minikube-linux-$arch
+minikube_version="1.34.0"
+curl -fsSL -O https://storage.googleapis.com/minikube/releases/v$minikube_version/minikube-linux-$arch
 
 # Supply chain security - minikube
-minikube_hash=$(get_checksum_from_github_release "kubernetes/minikube" "linux-$arch" "1.34.0" "SHA256")
+minikube_hash=$(get_checksum_from_github_release "kubernetes/minikube" "linux-$arch" "$minikube_version" "SHA256")
 use_checksum_comparison "minikube-linux-$arch" "${minikube_hash}"
 
 # Install minikube

--- a/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-20.04.pkr.hcl
@@ -270,7 +270,7 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type                   = "hvm"
   ami_groups                                = var.aws_private_ami ? [] : ["all"]
   ebs_optimized                             = true
-  spot_instance_types                       = ["m7i.xlarge"]
+  spot_instance_types                       = ["m7i.xlarge", "m6i.xlarge"]
   spot_price                                = "1.00"
   region                                    = "${var.aws_region}"
   ssh_username                              = "ubuntu"

--- a/images/ubuntu/templates/ubuntu-22.04.arm64.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.arm64.pkr.hcl
@@ -270,7 +270,7 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type                   = "hvm"
   ami_groups                                = var.aws_private_ami ? [] : ["all"]
   ebs_optimized                             = true
-  spot_instance_types                       = ["m7g.xlarge"]
+  spot_instance_types                       = ["m7g.xlarge", "m6g.xlarge"]
   spot_price                                = "1.00"
   region                                    = "${var.aws_region}"
   ssh_username                              = "ubuntu"

--- a/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-22.04.pkr.hcl
@@ -270,7 +270,7 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type                   = "hvm"
   ami_groups                                = var.aws_private_ami ? [] : ["all"]
   ebs_optimized                             = true
-  spot_instance_types                       = ["m7i.xlarge"]
+  spot_instance_types                       = ["m7i.xlarge", "m6i.xlarge"]
   spot_price                                = "1.00"
   region                                    = "${var.aws_region}"
   ssh_username                              = "ubuntu"

--- a/images/ubuntu/templates/ubuntu-24.04.arm64.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.arm64.pkr.hcl
@@ -270,7 +270,7 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type                   = "hvm"
   ami_groups                                = var.aws_private_ami ? [] : ["all"]
   ebs_optimized                             = true
-  spot_instance_types                       = ["m7g.xlarge"]
+  spot_instance_types                       = ["m7g.xlarge", "m6g.xlarge"]
   spot_price                                = "1.00"
   region                                    = "${var.aws_region}"
   ssh_username                              = "ubuntu"

--- a/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-24.04.pkr.hcl
@@ -270,7 +270,7 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type                   = "hvm"
   ami_groups                                = var.aws_private_ami ? [] : ["all"]
   ebs_optimized                             = true
-  spot_instance_types                       = ["m7i.xlarge"]
+  spot_instance_types                       = ["m7i.xlarge", "m6i.xlarge"]
   spot_price                                = "1.00"
   region                                    = "${var.aws_region}"
   ssh_username                              = "ubuntu"

--- a/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
+++ b/images/ubuntu/templates/ubuntu-minimal.pkr.hcl
@@ -256,7 +256,7 @@ source "amazon-ebs" "build_image" {
   ami_virtualization_type                   = "hvm"
   ami_groups                                = var.aws_private_ami ? [] : ["all"]
   ebs_optimized                             = true
-  spot_instance_types                       = ["m7i.xlarge"]
+  spot_instance_types                       = ["m7i.xlarge", "m6i.xlarge"]
   spot_price                                = "1.00"
   region                                    = "${var.aws_region}"
   ssh_username                              = "ubuntu"


### PR DESCRIPTION
We already don't specify an availability zone, but have been getting:
```
==> amazon-ebs.build_image: Error waiting for fleet request (fleet-359761ae-d32c-669c-a638-ad223b0c73bc) to become ready:We currently do not have sufficient m7i.xlarge capacity in the Availability Zone you requested (us-east-2a). Our system will be working on provisioning additional capacity. You can currently get m7i.xlarge capacity by not specifying an Availability Zone in your request or choosing us-east-2b, us-east-2c.
```

This specifies a fallback instance type.