### PR TITLE
Fix all zizmor findings

### DIFF
--- a/.github/actions/image-tests/action.yml
+++ b/.github/actions/image-tests/action.yml
@@ -1,21 +1,21 @@
-name: 'Image tests'
-description: 'Run tests on runner images from within workflow'
+name: "Image tests"
+description: "Run tests on runner images from within workflow"
 
 inputs:
   image_os:
-    description: 'The operating system of the image'
+    description: "The operating system of the image"
     required: false
-    default: 'ubuntu'
+    default: "ubuntu"
   os_version:
-    description: 'The version of the operating system of the image'
+    description: "The version of the operating system of the image"
     required: false
-    default: '2204'
+    default: "2204"
   image_tag:
-    description: 'The version of the image'
+    description: "The version of the image"
     required: true
 
 runs:
-  using: 'composite'
+  using: "composite"
   steps:
     - name: Checkout repository
       uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -47,6 +47,19 @@ runs:
 
     - name: Test runner expressions
       shell: bash
+      env:
+        CONTAINS_TRUE: ${{ contains('Hello World', 'World') }}
+        CONTAINS_FALSE: ${{ contains('Hello World', 'Goodbye') }}
+        STARTS_WITH_TRUE: ${{ startsWith('Hello World', 'Hello') }}
+        STARTS_WITH_FALSE: ${{ startsWith('Hello World', 'World') }}
+        ENDS_WITH_TRUE: ${{ endsWith('Hello World', 'World') }}
+        ENDS_WITH_FALSE: ${{ endsWith('Hello World', 'Hello') }}
+        FORMAT_TEST: ${{ format('Hello {0}{1}', 'World', '!') }}
+        JOIN_TEST: ${{ join(fromJSON('["Hello", "World"]'), ' ') }}
+        HASH_FILES_NON_EMPTY: ${{ hashFiles('runner-images') }}
+        HASH_FILES_EMPTY: ${{ hashFiles('/var/empty') }}
+        FROM_JSON_TEST: ${{ fromJSON('{"key":"value"}').key }}
+        TO_JSON_TEST: ${{ toJSON(fromJSON('{"key":"value"}')) }}
       run: |
         echo "::group::Test runner expressions"
         # Initialize the failed flag and counters
@@ -89,18 +102,18 @@ runs:
         mkdir empty-dir
         echo "Testing runner expressions..."
         start_time=$(date +%s)
-        check_result "contains (true)" "${{ contains('Hello World', 'World') }}" "true"
-        check_result "contains (false)" "${{ contains('Hello World', 'Goodbye') }}" "false"
-        check_result "startsWith (true)" "${{ startsWith('Hello World', 'Hello') }}" "true"
-        check_result "startsWith (false)" "${{ startsWith('Hello World', 'World') }}" "false"
-        check_result "endsWith (true)" "${{ endsWith('Hello World', 'World') }}" "true"
-        check_result "endsWith (false)" "${{ endsWith('Hello World', 'Hello') }}" "false"
-        check_result "format" "${{ format('Hello {0}{1}', 'World', '!') }}" "Hello World!"
-        check_result "join" "${{ join(fromJSON('["Hello", "World"]'), ' ') }}" "Hello World"
-        check_result "hashFiles (non-empty)" "${{ hashFiles('runner-images') }}" "non-empty"
-        check_result "hashFiles (empty)" "${{ hashFiles('empty-dir') }}" ""
-        check_result "fromJSON" "${{ fromJSON('{"key":"value"}').key }}" "value"
-        check_result "toJSON" "${{ toJSON(fromJSON('{"key":"value"}')) }}" '{
+        check_result "contains (true)" "$CONTAINS_TRUE" "true"
+        check_result "contains (false)" "$CONTAINS_FALSE" "false"
+        check_result "startsWith (true)" "$STARTS_WITH_TRUE" "true"
+        check_result "startsWith (false)" "$STARTS_WITH_FALSE" "false"
+        check_result "endsWith (true)" "$ENDS_WITH_TRUE" "true"
+        check_result "endsWith (false)" "$ENDS_WITH_FALSE" "false"
+        check_result "format" "$FORMAT_TEST" "Hello World!"
+        check_result "join" "$JOIN_TEST" "Hello World"
+        check_result "hashFiles (non-empty)" "$HASH_FILES_NON_EMPTY" "non-empty"
+        check_result "hashFiles (empty)" "$HASH_FILES_EMPTY" ""
+        check_result "fromJSON" "$FROM_JSON_TEST" "value"
+        check_result "toJSON" "$TO_JSON_TEST" '{
           key: value
         }'
 

--- a/.github/workflows/check-pinned-versions.yml
+++ b/.github/workflows/check-pinned-versions.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          persist-credentials: false
 
       - name: Validate JSON Schema
         shell: pwsh

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/create_github_release.yml
+++ b/.github/workflows/create_github_release.yml
@@ -4,6 +4,8 @@ on:
   repository_dispatch:
     types: [create-github-release]
 
+permissions:
+  contents: write
 
 jobs:
   Create_GitHub_release:
@@ -11,9 +13,11 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     - name: Create release for ${{ github.event.client_payload.ReleaseBranchName }}
-      uses: ncipollo/release-action@v1.14.0
+      uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0
       with:
         tag: ${{ github.event.client_payload.ReleaseBranchName }}
         name: ${{ github.event.client_payload.ReleaseTitle }}

--- a/.github/workflows/create_pull_request.yml
+++ b/.github/workflows/create_pull_request.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [create-pr]
 
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   Create_pull_request:
@@ -13,37 +16,47 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
 
     - name: Clone release branch to create pull request
+      env:
+        RELEASE_BRANCH_NAME: ${{ github.event.client_payload.ReleaseBranchName }}
       run: |
-        git checkout ${{ github.event.client_payload.ReleaseBranchName }}
-        git branch ${{ github.event.client_payload.ReleaseBranchName }}-docs
-        git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs --force
+        git checkout "$RELEASE_BRANCH_NAME"
+        git branch "${RELEASE_BRANCH_NAME}-docs"
+        git push origin "${RELEASE_BRANCH_NAME}-docs" --force
 
-    - name: Create pull request for ${{ github.event.client_payload.ReleaseBranchName }}
+    - name: Create pull request
       id: create-pr
       uses: actions/github-script@v7
+      env:
+        PR_TITLE: ${{ github.event.client_payload.PullRequestTitle }}
+        RELEASE_BRANCH_NAME: ${{ github.event.client_payload.ReleaseBranchName }}
+        PR_BASE: ${{ github.event.client_payload.PullRequestBase }}
+        PR_BODY: ${{ github.event.client_payload.PullRequestBody }}
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           let response = await github.rest.pulls.create({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            title: "${{ github.event.client_payload.PullRequestTitle }}",
-            head: "${{ github.event.client_payload.ReleaseBranchName }}-docs",
-            base: "${{ github.event.client_payload.PullRequestBase }}",
-            body: `${{ github.event.client_payload.PullRequestBody }}`
+            title: process.env.PR_TITLE,
+            head: `${process.env.RELEASE_BRANCH_NAME}-docs`,
+            base: process.env.PR_BASE,
+            body: process.env.PR_BODY
           });
           return response.data.number
 
     - name: Request reviewers
       uses: actions/github-script@v7
+      env:
+        PR_NUMBER: ${{ steps.create-pr.outputs.result }}
       with:
         github-token: ${{secrets.PRAPPROVAL_SECRET}}
         script: |
           github.rest.pulls.requestReviewers({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              pull_number: ${{ steps.create-pr.outputs.result }},
+              pull_number: Number(process.env.PR_NUMBER),
               team_reviewers: ['runner-images-team']
           })

--- a/.github/workflows/create_sbom_report.yml
+++ b/.github/workflows/create_sbom_report.yml
@@ -11,48 +11,62 @@ run-name: Collecting SBOM for ${{ github.event.client_payload.ReleaseBranchName 
 on:
   repository_dispatch:
     types: [generate-sbom]
+
+permissions:
+  contents: write
+
 defaults:
   run:
     shell: pwsh
 jobs:
   #Checking current release for SBOM
   sbom-check:
+    permissions:
+      contents: read
     outputs:
       check_status: ${{ steps.check.outputs.status }}
     runs-on: ubuntu-latest
     steps:
-    - name: Check release for ${{ github.event.client_payload.ReleaseBranchName }}
+    - name: Check release
       id: check
       shell: pwsh
+      env:
+        RELEASE_ID: ${{ github.event.client_payload.ReleaseID }}
+        RELEASE_BRANCH_NAME: ${{ github.event.client_payload.ReleaseBranchName }}
       run: |
-        $apiUrl = "https://api.github.com/repos/actions/runner-images/releases/${{ github.event.client_payload.ReleaseID }}"
+        $apiUrl = "https://api.github.com/repos/actions/runner-images/releases/$env:RELEASE_ID"
         $response = Invoke-RestMethod -Uri $apiUrl -Method Get -SkipHttpErrorCheck
         if ($response.message -ilike "Not Found") {
           echo "status=release_not_found" >> $env:GITHUB_OUTPUT
-          Write-Error "Release ${{ github.event.client_payload.ReleaseID }} wasn't found"
+          Write-Error "Release $env:RELEASE_ID wasn't found"
           exit 1
         }
         foreach ($asset in $response.assets) {
           if ($asset.name -like '*sbom*') {
             echo "status=sbom_exists" >> $env:GITHUB_OUTPUT
-            return "Release ${{ github.event.client_payload.ReleaseID }} already contains a SBOM"
+            return "Release $env:RELEASE_ID already contains a SBOM"
           }
         }
         Write-Host "Release has been found, SBOM is not attached, starting generation."
         echo "status=okay" >> $env:GITHUB_OUTPUT
   #Generating SBOM
   building-sbom:
+    permissions:
+      contents: write
     needs: sbom-check
     if: ${{ needs.sbom-check.outputs.check_status == 'okay' }}
     runs-on: ${{ github.event.client_payload.agentSpec }}
     steps:
-      - name: Available image version check for ${{ github.event.client_payload.ReleaseBranchName }}
+      - name: Available image version check
+        env:
+          RELEASE_BRANCH_NAME: ${{ github.event.client_payload.ReleaseBranchName }}
+          IMAGE_VERSION: ${{ github.event.client_payload.imageVersion }}
         run: |
           $imageVersionComponents = $env:ImageVersion.Split('.')
           $imageMajorVersion = $imageVersionComponents[0]
           $imageMinorVersion = $imageVersionComponents[1]
-          if ("$imageMajorVersion.$imageMinorVersion" -ne '${{ github.event.client_payload.imageVersion }}') {
-            throw "Current runner $imageMajorVersion.$imageMinorVersion image version doesn't match ${{ github.event.client_payload.imageVersion }}."
+          if ("$imageMajorVersion.$imageMinorVersion" -ne "$env:IMAGE_VERSION") {
+            throw "Current runner $imageMajorVersion.$imageMinorVersion image version doesn't match $env:IMAGE_VERSION."
           }
       - name: Install SYFT tool on Windows
         if: ${{ runner.os == 'Windows' }}
@@ -86,8 +100,10 @@ jobs:
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_ID: ${{ github.event.client_payload.ReleaseID }}
+          AGENT_SPEC: ${{ github.event.client_payload.agentSpec }}
         with:
-          upload_url: "https://uploads.github.com/repos/actions/runner-images/releases/${{ github.event.client_payload.ReleaseID }}/assets{?name,label}"
+          upload_url: "https://uploads.github.com/repos/actions/runner-images/releases/${{ env.RELEASE_ID }}/assets{?name,label}"
           asset_path: ./sbom.json.zip
-          asset_name: sbom.${{ github.event.client_payload.agentSpec }}.json.zip
+          asset_name: sbom.${{ env.AGENT_SPEC }}.json.zip
           asset_content_type: application/zip

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,16 +10,22 @@ on:
       - '**.md'
       - '**.sh'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Lint JSON & MD files
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Lint Code Base
         uses: github/super-linter/slim@v4

--- a/.github/workflows/merge_pull_request.yml
+++ b/.github/workflows/merge_pull_request.yml
@@ -4,6 +4,9 @@ on:
   repository_dispatch:
     types: [merge-pr]
 
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   Merge_pull_request:
@@ -13,36 +16,43 @@ jobs:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
+        persist-credentials: false
 
-    - name: Resolve possible conflicts ${{ github.event.client_payload.ReleaseBranchName }} with main
+    - name: Resolve possible conflicts with main
+      env:
+        RELEASE_BRANCH_NAME: ${{ github.event.client_payload.ReleaseBranchName }}
       run: |
         git config --global user.email "no-reply@github.com"
         git config --global user.name "Actions service account"
-        git checkout ${{ github.event.client_payload.ReleaseBranchName }}-docs
+        git checkout "${RELEASE_BRANCH_NAME}-docs"
         git merge --no-edit --strategy-option=ours main
-        git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs
+        git push origin "${RELEASE_BRANCH_NAME}-docs"
         sleep 30
 
     - name: Approve pull request by GitHub-Actions bot
       uses: actions/github-script@v7
+      env:
+        PR_NUMBER: ${{ github.event.client_payload.PullRequestNumber }}
       with:
         github-token: ${{secrets.PRAPPROVAL_SECRET}}
         script: |
           github.rest.pulls.createReview({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            pull_number: ${{ github.event.client_payload.PullRequestNumber }},
+            pull_number: Number(process.env.PR_NUMBER),
             event: "APPROVE"
           });
 
-    - name: Merge pull request for ${{ github.event.client_payload.ReleaseBranchName }}
+    - name: Merge pull request
       uses: actions/github-script@v7
+      env:
+        PR_NUMBER: ${{ github.event.client_payload.PullRequestNumber }}
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
           github.rest.pulls.merge({
             owner: context.repo.owner,
             repo: context.repo.repo,
-            pull_number: ${{ github.event.client_payload.PullRequestNumber }},
+            pull_number: Number(process.env.PR_NUMBER),
             merge_method: "squash"
           })

--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -18,12 +18,15 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: main
+          persist-credentials: false
 
       - name: Check if main branch contains the tagged commit
         id: is_main
+        env:
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           git fetch origin main --depth=$((2**31 - 1)) # Fetch all commits from main
-          is_main=$([ -n "$(git branch -r --contains ${{ github.sha }} origin/main)" ] && echo true || echo false)
+          is_main=$([ -n "$(git branch -r --contains $GITHUB_SHA origin/main)" ] && echo true || echo false)
           echo "value=$is_main" >> "${GITHUB_OUTPUT}"
 
   check-release:
@@ -37,13 +40,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Find release for the commit
         id: get_release_by_commit
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_SHA: ${{ github.sha }}
         run: |
           # Fetch last 100 releases (it sorts by latest, last 100 should be enough)
-          releases=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "${{ github.api_url }}/repos/${{ github.repository }}/releases?per_page=100")
+          releases=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases?per_page=100")
 
           # Iterate over each release
           while read -r release; do
@@ -53,14 +63,14 @@ jobs:
             body=$(echo "$release" | jq -r '.body')
 
             # Get the commit for the tag
-            tag_info=$(curl -s -H "Authorization: token ${{ github.token }}" \
-              "${{ github.api_url }}/repos/${{ github.repository }}/git/refs/tags/${tag_name}")
+            tag_info=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/git/refs/tags/${tag_name}")
 
             # Handle annotated and lightweight tags
             tag_type=$(echo "$tag_info" | jq -r '.object.type')
             if [ "$tag_type" = "tag" ]; then
               # Annotated tag, get the commit from the tag object
-              tag_object=$(curl -s -H "Authorization: token ${{ github.token }}" \
+              tag_object=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
                 "$(echo "$tag_info" | jq -r '.object.url')")
               commit_sha=$(echo "$tag_object" | jq -r '.object.sha')
             else
@@ -68,7 +78,7 @@ jobs:
               commit_sha=$(echo "$tag_info" | jq -r '.object.sha')
             fi
 
-            if [ "$commit_sha" = "${{ github.sha }}" ]; then
+            if [ "$commit_sha" = "$GITHUB_SHA" ]; then
               echo "Release found (ID: $release_id)"
               echo "release_found=true" >> $GITHUB_OUTPUT
               echo "release_id=$release_id" >> $GITHUB_OUTPUT
@@ -81,7 +91,7 @@ jobs:
             fi
           done < <(echo "$releases" | jq -c '.[]')
 
-          echo "No release found for commit ${{ github.sha }}"
+          echo "No release found for commit $GITHUB_SHA"
           echo "release_found=false" >> $GITHUB_OUTPUT
 
   build:
@@ -104,6 +114,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Assume OIDC role
         id: auth
@@ -170,21 +182,25 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_JOB_WORKFLOW_REF: ${{ steps.auth.outputs.job_workflow_ref }}
           GITHUB_REPOSITORY_NAME: ${{ steps.auth.outputs.repository_name }}
+          TEMPLATE: ${{ matrix.template }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
-          packer init ${{ matrix.template }}
+          packer init "$TEMPLATE"
           packer build \
             -var provider=aws \
             -var aws_private_ami=true \
-            -var image_version="${{ github.ref_name }}" \
+            -var image_version="$REF_NAME" \
             -var aws_assume_role_arn="arn:aws:iam::${{ env.AWS_ACCOUNT }}:role/github-actions/packer-role" \
             -var aws_assume_role_session_name=GitHubActions \
-            ${{ matrix.template }}
+            "$TEMPLATE"
 
       - name: Preapre artifacts
         id: artifacts
+        env:
+          TEMPLATE: ${{ matrix.template }}
         run: |
           mkdir -p artifacts
-          name=$(basename -s .pkr.hcl ${{ matrix.template }})
+          name=$(basename -s .pkr.hcl $TEMPLATE)
           readme=$(git ls-files --others --exclude-standard -- '**/software-report.md')
           mv "$readme" artifacts/${name}-software-report.md
           report=$(git ls-files --others --exclude-standard -- '**/software-report.json')
@@ -195,8 +211,10 @@ jobs:
 
       - name: Upload artifacts
         uses: actions/upload-artifact@834a144ee995460fba8ed112a2fc961b36a5ec5a # v4.3.6
+        env:
+          ARTIFACT_NAME: ${{ steps.artifacts.outputs.name }}
         with:
-          name: "Artifacts for ${{ steps.artifacts.outputs.name }}.pkr.hcl"
+          name: "Artifacts for ${{ env.ARTIFACT_NAME }}.pkr.hcl"
           path: artifacts
 
   publish:
@@ -214,6 +232,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       # If no release exists, download artifacts from the build job
       - name: Download artifacts from build job
@@ -224,6 +244,8 @@ jobs:
 
       - name: Check if latest
         id: is_latest
+        env:
+          REF_NAME: ${{ github.ref_name }}
         run: |
           # Fetch all tags from the repository
           git fetch --tags
@@ -235,7 +257,7 @@ jobs:
           latest_tag=$(echo "$tags" | sort -V | tail -n 1)
 
           # Compare the tag_to_check with the latest tag
-          if [ "${{ github.ref_name }}" = "$latest_tag" ]; then
+          if [ "$REF_NAME" = "$latest_tag" ]; then
               echo "value=true" >> "${GITHUB_OUTPUT}"
           else
               echo "value=false" >> "${GITHUB_OUTPUT}"
@@ -245,10 +267,16 @@ jobs:
         id: publish
         if: needs.check-release.outputs.release_found == 'false'
         uses: softprops/action-gh-release@c062e08bd532815e2082a85e87e3ef29c3e6d191 # v2.0.8
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          IS_LATEST: ${{ steps.is_latest.outputs.value }}
         with:
           files: artifacts/**/*
           body: |
-            Release ${{ github.ref_name }} from workflow [#${{ github.run_id }}](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            Release ${{ env.REF_NAME }} from workflow [#${{ env.GITHUB_RUN_ID }}](${{ env.GITHUB_SERVER_URL }}/${{ env.GITHUB_REPOSITORY }}/actions/runs/${{ env.GITHUB_RUN_ID }})
           draft: ${{ env.PROD_RELEASE == 'false' }}
           make_latest: ${{ env.PROD_RELEASE == 'true' && steps.is_latest.outputs.value }}
           generate_release_notes: true
@@ -259,17 +287,26 @@ jobs:
         env:
           RELEASE_BODY: ${{ needs.check-release.outputs.body }}
           RELEASE_TAG: ${{ needs.check-release.outputs.tag }}
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          REF_NAME: ${{ github.ref_name }}
+          RELEASE_ID: ${{ needs.check-release.outputs.release_id }}
+          PROD_RELEASE: ${{ env.PROD_RELEASE }}
+          IS_LATEST: ${{ steps.is_latest.outputs.value }}
+          DRAFT_STATUS: ${{ env.PROD_RELEASE == 'false' }}
+          MAKE_LATEST: ${{ env.PROD_RELEASE == 'true' && steps.is_latest.outputs.value }}
         run: |
           curl -X PATCH \
             -H "Accept: application/vnd.github+json" \
-            -H "Authorization: token ${{ github.token }}" \
-            ${{ github.api_url }}/repos/${{ github.repository }}/releases/${{ needs.check-release.outputs.release_id }} \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            $GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID \
             -d "$(jq -n \
-              --arg name "${{ github.ref_name }}" \
-              --arg tag_name "${{ github.ref_name }}" \
-              --argjson draft ${{ env.PROD_RELEASE == 'false' }} \
-              --arg make_latest "${{ env.PROD_RELEASE == 'true' && steps.is_latest.outputs.value }}" \
-              --arg body "$(echo "$RELEASE_BODY" | sed "/Release .* from workflow/ s/$RELEASE_TAG/${{ github.ref_name }}/g; /Full Changelog/ s/$RELEASE_TAG/${{ github.ref_name }}/g")" \
+              --arg name "$REF_NAME" \
+              --arg tag_name "$REF_NAME" \
+              --argjson draft $DRAFT_STATUS \
+              --arg make_latest "$MAKE_LATEST" \
+              --arg body "$(echo "$RELEASE_BODY" | sed "/Release .* from workflow/ s/$RELEASE_TAG/$REF_NAME/g; /Full Changelog/ s/$RELEASE_TAG/$REF_NAME/g")" \
               '{name: $name, tag_name: $tag_name, draft: $draft, make_latest: $make_latest, body: $body}' \
             )"
 
@@ -287,24 +324,31 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          persist-credentials: false
 
       - name: Download manifest assets
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RELEASE_ID: ${{ needs.publish.outputs.release_id }}
         run: |
           # Get the list of assets for the specified release
-          assets=$(curl -s -H "Authorization: token ${{ github.token }}" \
-            "${{ github.api_url }}/repos/${{ github.repository }}/releases/${{ needs.publish.outputs.release_id }}/assets")
+          assets=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
+            "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/$RELEASE_ID/assets")
 
           # Filter assets matching the pattern and download each one
           echo "$assets" | jq -r '.[] | select(.name | test(".*build-manifest\\.json$")) | "\(.id) \(.name)"' | while read -r asset_id asset_name; do
             echo "Downloading $asset_name (ID: $asset_id)"
             curl -L -H "Accept: application/octet-stream" \
-              -H "Authorization: token ${{ github.token }}" \
-              "${{ github.api_url }}/repos/${{ github.repository }}/releases/assets/${asset_id}" \
+              -H "Authorization: token $GITHUB_TOKEN" \
+              "$GITHUB_API_URL/repos/$GITHUB_REPOSITORY/releases/assets/${asset_id}" \
               -o "${asset_name}"
           done
 
       - name: Authenticate with Dev AWS Account
-        uses: grafana/shared-workflows/actions/aws-auth@main
+        uses: grafana/shared-workflows/actions/aws-auth@abb283a39f2ddc434391d0e5d9a994f74bf20e35 # aws-auth-v1.0.1
         with:
           aws-region: "us-east-2"
           role-arn: "arn:aws:iam::${{ env.DEV_ACCOUNT }}:role/github-actions/packer-role"
@@ -338,7 +382,7 @@ jobs:
           done
 
       - name: Authenticate with Prod AWS Account
-        uses: grafana/shared-workflows/actions/aws-auth@main
+        uses: grafana/shared-workflows/actions/aws-auth@abb283a39f2ddc434391d0e5d9a994f74bf20e35 # aws-auth-v1.0.1
         with:
           aws-region: "us-east-2"
           role-arn: "arn:aws:iam::${{ env.PROD_ACCOUNT }}:role/github-actions/packer-role"

--- a/.github/workflows/powershell-tests.yml
+++ b/.github/workflows/powershell-tests.yml
@@ -1,25 +1,32 @@
-# CI Validation
+# CI PowerShell Validation
 
-name: PowerShell Tests
+name: PowerShell tests
 
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
     paths:
-      - 'helpers/software-report-base/**'
+      - 'helpers/**'
+
+permissions:
+  contents: read
 
 jobs:
   powershell-tests:
     name: PowerShell tests
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
-      - name: Run Software Report module tests
+      - name: Run tests
         shell: pwsh
         run: |
-            $ErrorActionPreference = "Stop"
-            Invoke-Pester -Output Detailed "helpers/software-report-base/tests"
+          Install-Module -Name Pester -Force
+          Invoke-Pester -Output Detailed "helpers/software-report-base/tests"
         

--- a/.github/workflows/sync-upstream-change.yml
+++ b/.github/workflows/sync-upstream-change.yml
@@ -18,7 +18,7 @@ jobs:
       github.event.review.body == 'bot change'
     steps:
       - name: Retrieve secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
         with:
           repo_secrets: |
             APP_ID=app:id
@@ -37,6 +37,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
 
       - name: Reset branch to main
         run: |
@@ -57,8 +58,10 @@ jobs:
           git merge $SHA || echo "conflicts=true" >> $GITHUB_OUTPUT
 
       - name: Push changes to branch
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git push -f origin ${{ github.event.pull_request.head.ref }}
+          git push -f origin "$HEAD_REF"
 
       - name: Set PR body
         id: pr-body
@@ -70,9 +73,10 @@ jobs:
           UPSTREAM_SHA: "${{ steps.merge.outputs.upstream-sha }}"
           PR_BODY_NO_CONFLICTS_TEMPLATE: ".github/workflows/sync-upstream/templates/pr-body-no-conflicts.txt"
           PR_BODY_WITH_CONFLICTS_TEMPLATE: ".github/workflows/sync-upstream/templates/pr-body-with-conflicts.txt"
+          MERGE_CONFLICTS: "${{ steps.merge.outputs.conflicts }}"
         run: |
           echo 'body<<EOF' >> $GITHUB_OUTPUT
-          if [ "${{ steps.merge.outputs.conflicts }}" == "true" ]; then
+          if [ "$MERGE_CONFLICTS" == "true" ]; then
             envsubst < $PR_BODY_WITH_CONFLICTS_TEMPLATE  >> $GITHUB_OUTPUT
           else
             envsubst < $PR_BODY_NO_CONFLICTS_TEMPLATE  >> $GITHUB_OUTPUT
@@ -82,7 +86,10 @@ jobs:
       - name: Edit pull request
         env:
           GH_TOKEN: ${{ github.token }}
+          RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_REPO: ${{ github.repository }}
+          PR_BODY: ${{ steps.pr-body.outputs.body }}
         run: |
-          gh pr edit sync-upstream-${{ github.run_number }} \
-          --repo ${{ github.repository }} \
-          --body '${{ steps.pr-body.outputs.body }}'
+          gh pr edit sync-upstream-$RUN_NUMBER \
+          --repo $GITHUB_REPO \
+          --body '$PR_BODY'

--- a/.github/workflows/sync-upstream-create.yml
+++ b/.github/workflows/sync-upstream-create.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Retrieve secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
         with:
           repo_secrets: |
             APP_ID=app:id
@@ -34,6 +34,7 @@ jobs:
           fetch-depth: 0
           ref: main
           token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
 
       - name: Create new branch from main
         run: |
@@ -75,9 +76,10 @@ jobs:
           UPSTREAM_SHA: "${{ steps.merge.outputs.upstream-sha }}"
           PR_BODY_NO_CONFLICTS_TEMPLATE: ".github/workflows/sync-upstream/templates/pr-body-no-conflicts.txt"
           PR_BODY_WITH_CONFLICTS_TEMPLATE: ".github/workflows/sync-upstream/templates/pr-body-with-conflicts.txt"
+          HAS_CONFLICTS: "${{ steps.merge.outputs.conflicts }}"
         run: |
           echo 'body<<EOF' >> $GITHUB_OUTPUT
-          if [ "${{ steps.merge.outputs.conflicts }}" == "true" ]; then
+          if [ "$HAS_CONFLICTS" == "true" ]; then
             envsubst < $PR_BODY_WITH_CONFLICTS_TEMPLATE  >> $GITHUB_OUTPUT
           else
             envsubst < $PR_BODY_NO_CONFLICTS_TEMPLATE  >> $GITHUB_OUTPUT
@@ -87,12 +89,15 @@ jobs:
       - name: Create pull request
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_BODY: ${{ steps.pr-body.outputs.body }}
+          RUN_NUMBER: ${{ github.run_number }}
+          REPOSITORY: ${{ github.repository }}
         run: |
           gh pr create --title 'Update from upstream' \
-          --body '${{ steps.pr-body.outputs.body }}' \
-          --base main --head sync-upstream-${{ github.run_number }} \
-          --repo ${{ github.repository }} \
+          --body "$PR_BODY" \
+          --base main --head sync-upstream-$RUN_NUMBER \
+          --repo $REPOSITORY \
           || \
-          gh pr edit sync-upstream-${{ github.run_number }} \
-          --repo ${{ github.repository }} \
-          --body '${{ steps.pr-body.outputs.body }}'
+          gh pr edit sync-upstream-$RUN_NUMBER \
+          --repo $REPOSITORY \
+          --body "$PR_BODY"

--- a/.github/workflows/sync-upstream-merge.yml
+++ b/.github/workflows/sync-upstream-merge.yml
@@ -18,7 +18,7 @@ jobs:
       github.event.review.body == 'bot merge'
     steps:
       - name: Retrieve secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@28361cdb22223e5f1e34358c86c20908e7248760 # get-vault-secrets-v1.1.0
         with:
           repo_secrets: |
             APP_ID=app:id
@@ -37,6 +37,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.generate-token.outputs.token }}
+          persist-credentials: false
 
       - name: Configure Git
         run: |
@@ -53,17 +54,21 @@ jobs:
 
       - name: Delete branch on success
         if: ${{ success() }}
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: |
-          git push -d origin ${{ github.event.pull_request.head.ref }}
+          git push -d origin "$HEAD_REF"
 
       - name: Comment error on failure
         if: ${{ failure() }}
         env:
           GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PUSH_OUTPUT: ${{ steps.push.outputs.output }}
         run: |
-          gh pr comment ${{ github.event.pull_request.number }} --body 'Failed to push changes to main.
+          gh pr comment $PR_NUMBER --body 'Failed to push changes to main.
 
           Output:
           ```
-          ${{ steps.push.outputs.output }}
+          '"$PUSH_OUTPUT"'
           ```'

--- a/.github/workflows/tag-build-and-publish.yml
+++ b/.github/workflows/tag-build-and-publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - "v*"
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish:
     uses: grafana/runner-images/.github/workflows/packer-build-and-publish.yml@main

--- a/.github/workflows/trigger-ubuntu-win-build.yml
+++ b/.github/workflows/trigger-ubuntu-win-build.yml
@@ -6,6 +6,14 @@ on:
       image_type:
         required: true
         type: string
+    secrets:
+      CI_PR_TOKEN:
+        required: true
+      CI_REPO:
+        required: true
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -13,6 +21,8 @@ defaults:
 
 jobs:
   trigger-workflow:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Trigger Build workflow
@@ -20,6 +30,9 @@ jobs:
           CI_PR_TOKEN: ${{ secrets.CI_PR_TOKEN }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           CI_PR: ${{ secrets.CI_REPO }}
+          IMAGE_TYPE: ${{ inputs.image_type }}
+          REPO_FULL_NAME: ${{ github.event.pull_request.head.repo.full_name }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           $headers = @{
             Authorization="Bearer $env:CI_PR_TOKEN"
@@ -28,13 +41,13 @@ jobs:
           # Private repository for builds
           $apiRepoUrl = "https://api.github.com/repos/$env:CI_PR"
 
-          $eventType = "trigger-${{ inputs.image_type }}-build"
+          $eventType = "trigger-$env:IMAGE_TYPE-build"
           $body = @{
             event_type = $eventType;
             client_payload = @{
               pr_title = "$env:PR_TITLE"
-              custom_repo = "${{ github.event.pull_request.head.repo.full_name }}"
-              custom_repo_commit_hash = "${{ github.event.pull_request.head.sha }}"
+              custom_repo = "$env:REPO_FULL_NAME"
+              custom_repo_commit_hash = "$env:COMMIT_SHA"
             }
           }
 

--- a/.github/workflows/ubuntu2004.yml
+++ b/.github/workflows/ubuntu2004.yml
@@ -2,10 +2,13 @@ name: Trigger Ubuntu20.04 CI
 run-name: Ubuntu20.04 - ${{ github.event.pull_request.title }}
 
 on:
-  pull_request_target:
+  pull_request:
     types: labeled
     paths:
     - 'images/ubuntu/**'
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -13,8 +16,12 @@ defaults:
 
 jobs:
   Ubuntu_2004:
+    permissions:
+      contents: read
     if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2004'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'ubuntu2004'
-    secrets: inherit
+    secrets:
+      CI_PR_TOKEN: ${{ secrets.CI_PR_TOKEN }}
+      CI_REPO: ${{ secrets.CI_REPO }}

--- a/.github/workflows/ubuntu2204.yml
+++ b/.github/workflows/ubuntu2204.yml
@@ -2,10 +2,13 @@ name: Trigger Ubuntu22.04 CI
 run-name: Ubuntu22.04 - ${{ github.event.pull_request.title }}
 
 on:
-  pull_request_target:
+  pull_request:
     types: labeled
     paths:
     - 'images/ubuntu/**'
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -13,8 +16,12 @@ defaults:
 
 jobs:
   Ubuntu_2204:
+    permissions:
+      contents: read
     if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2204'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'ubuntu2204'
-    secrets: inherit
+    secrets:
+      CI_PR_TOKEN: ${{ secrets.CI_PR_TOKEN }}
+      CI_REPO: ${{ secrets.CI_REPO }}

--- a/.github/workflows/ubuntu2404.yml
+++ b/.github/workflows/ubuntu2404.yml
@@ -2,10 +2,13 @@ name: Trigger Ubuntu24.04 CI
 run-name: Ubuntu24.04 - ${{ github.event.pull_request.title }}
 
 on:
-  pull_request_target:
+  pull_request:
     types: labeled
     paths:
     - 'images/ubuntu/**'
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -13,8 +16,12 @@ defaults:
 
 jobs:
   Ubuntu_2404:
+    permissions:
+      contents: read
     if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2404'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'ubuntu2404'
-    secrets: inherit
+    secrets:
+      CI_PR_TOKEN: ${{ secrets.CI_PR_TOKEN }}
+      CI_REPO: ${{ secrets.CI_REPO }}

--- a/.github/workflows/update_github_release.yml
+++ b/.github/workflows/update_github_release.yml
@@ -4,6 +4,8 @@ on:
   repository_dispatch:
     types: [update-github-release]
 
+permissions:
+  contents: write
 
 jobs:
   Update_GitHub_release:
@@ -11,20 +13,25 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
-    - name: Update release for ${{ github.event.client_payload.ReleaseBranchName }}
+    - name: Update release
       uses: actions/github-script@v7
+      env:
+        RELEASE_BRANCH_NAME: ${{ github.event.client_payload.ReleaseBranchName }}
+        PRERELEASE: ${{ github.event.client_payload.Prerelease }}
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
         script: |
             const response = await github.rest.repos.getReleaseByTag({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              tag: "${{ github.event.client_payload.ReleaseBranchName }}"
+              tag: process.env.RELEASE_BRANCH_NAME
             });
             github.rest.repos.updateRelease({
               owner: context.repo.owner,
               repo: context.repo.repo,
               release_id: response.data.id,
-              prerelease: ${{ github.event.client_payload.Prerelease }}
+              prerelease: process.env.PRERELEASE === 'true'
             });

--- a/.github/workflows/validate-json-schema.yml
+++ b/.github/workflows/validate-json-schema.yml
@@ -1,20 +1,27 @@
+# CI Validation
+
 name: Validate JSON Schema
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
+    paths:
+      - 'images/win/**'
+
+permissions:
+  contents: read
 
 jobs:
   validate-json-schema:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
-
-      - name: Validate JSON Schema
+        with:
+          persist-credentials: false
+      - name: Validate JSON schema
         shell: pwsh
         run: ./helpers/CheckJsonSchema.ps1

--- a/.github/workflows/windows2019.yml
+++ b/.github/workflows/windows2019.yml
@@ -1,11 +1,14 @@
-name: Trigger Windows19 CI
+name: Trigger Windows2019 CI
 run-name: Windows2019 - ${{ github.event.pull_request.title }}
 
 on:
-  pull_request_target:
+  pull_request:
     types: labeled
     paths:
     - 'images/windows/**'
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -13,8 +16,12 @@ defaults:
 
 jobs:
   Windows_2019:
+    permissions:
+      contents: read
     if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-2019'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'windows2019'
-    secrets: inherit
+    secrets:
+      CI_PR_TOKEN: ${{ secrets.CI_PR_TOKEN }}
+      CI_REPO: ${{ secrets.CI_REPO }}

--- a/.github/workflows/windows2022.yml
+++ b/.github/workflows/windows2022.yml
@@ -1,11 +1,14 @@
-name: Trigger Windows22 CI
+name: Trigger Windows2022 CI
 run-name: Windows2022 - ${{ github.event.pull_request.title }}
 
 on:
-  pull_request_target:
+  pull_request:
     types: labeled
     paths:
     - 'images/windows/**'
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -13,8 +16,12 @@ defaults:
 
 jobs:
   Windows_2022:
+    permissions:
+      contents: read
     if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-2022'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'windows2022'
-    secrets: inherit
+    secrets:
+      CI_PR_TOKEN: ${{ secrets.CI_PR_TOKEN }}
+      CI_REPO: ${{ secrets.CI_REPO }}

--- a/.github/workflows/windows2025.yml
+++ b/.github/workflows/windows2025.yml
@@ -2,10 +2,13 @@ name: Trigger Windows25 CI
 run-name: Windows2025 - ${{ github.event.pull_request.title }}
 
 on:
-  pull_request_target:
+  pull_request:
     types: labeled
     paths:
     - 'images/windows/**'
+
+permissions:
+  contents: read
 
 defaults:
   run:
@@ -13,8 +16,12 @@ defaults:
 
 jobs:
   Windows_2022:
+    permissions:
+      contents: read
     if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-2025'
     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
     with:
       image_type: 'windows2025'
-    secrets: inherit
+    secrets:
+      CI_PR_TOKEN: ${{ secrets.CI_PR_TOKEN }}
+      CI_REPO: ${{ secrets.CI_REPO }}


### PR DESCRIPTION
This pull request introduces multiple updates across GitHub Actions workflows to enhance maintainability, security, and functionality. Key changes include standardizing string formatting, improving environment variable usage, adding permissions for workflows, and enhancing workflow logic to use environment variables for input sanitization.

This might break some actions or cause some conflicts on future merges from upstream, but it will be limited only to the next merge and shouldn't cause too many issues, it's better to fix all these vulnerabilities first and later address issues as they come up since the CI in this repository is not critical, the worse that could happen is delay the update of our runner images by a day or two.

Fix all the `zizmor` findings here:
<details><summary>Findings</summary>

```
 INFO zizmor: skipping forbidden-uses: audit not configured
 INFO audit: zizmor: 🌈 completed ./.github/actions/image-tests/action.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/check-pinned-versions.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/codeql-analysis.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/create_github_release.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/create_pull_request.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/create_sbom_report.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/linter.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/merge_pull_request.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/packer-build-and-publish.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/powershell-tests.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/sync-upstream-change.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/sync-upstream-create.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/sync-upstream-merge.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/tag-build-and-publish.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/trigger-ubuntu-win-build.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ubuntu2004.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ubuntu2204.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/ubuntu2404.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/update_github_release.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/validate-json-schema.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/windows2019.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/windows2022.yml
 INFO audit: zizmor: 🌈 completed ./.github/workflows/windows2025.yml
info[template-injection]: code injection via template expansion
   --> ./.github/actions/image-tests/action.yml:48:7
    |
 48 |       - name: Test runner expressions
    |         ----------------------------- info: this step
 49 |         shell: bash
 50 | /       run: |
 51 | |         echo "::group::Test runner expressions"
...   |
119 | |         fi
120 | |         echo "::endgroup::"
    | |____________________________- info: fromJSON('{"key":"value"}').key may expand into attacker-controllable code
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/check-pinned-versions.yml:15:9
   |
15 |         - name: Checkout repository
   |  _________-
16 | |         uses: actions/checkout@v3
   | |_________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/codeql-analysis.yml:42:7
   |
42 |       - name: Checkout repository
   |  _______-
43 | |       uses: actions/checkout@v4
44 | |
45 | |     # Initializes the CodeQL tools for scanning.
   | |________________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/create_github_release.yml:13:7
   |
13 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/create_github_release.yml:9:3
   |
 9 | /   Create_GitHub_release:
10 | |     runs-on: ubuntu-latest
...  |
21 | |         prerelease: ${{ github.event.client_payload.Prerelease }}
22 | |         commit: ${{ github.event.client_payload.Commitish }}
   | |                                                             -
   | |_____________________________________________________________|
   |                                                               this job
   |                                                               default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/create_github_release.yml:16:7
   |
16 |       uses: ncipollo/release-action@v1.14.0
   |       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/create_pull_request.yml:13:7
   |
13 |       - uses: actions/checkout@v4
   |  _______-
14 | |       with:
15 | |         fetch-depth: 0
   | |______________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/create_pull_request.yml:9:3
   |
 9 | /   Create_pull_request:
10 | |     runs-on: ubuntu-latest
...  |
48 | |               team_reviewers: ['runner-images-team']
49 | |           })
   | |             -
   | |_____________|
   |               this job
   |               default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_pull_request.yml:17:7
   |
17 |       - name: Clone release branch to create pull request
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
18 | /       run: |
19 | |         git checkout ${{ github.event.client_payload.ReleaseBranchName }}
20 | |         git branch ${{ github.event.client_payload.ReleaseBranchName }}-docs
21 | |         git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs --force
   | |_________________________________________________________________________________________^ github.event.client_payload.ReleaseBranchName may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_pull_request.yml:17:7
   |
17 |       - name: Clone release branch to create pull request
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
18 | /       run: |
19 | |         git checkout ${{ github.event.client_payload.ReleaseBranchName }}
20 | |         git branch ${{ github.event.client_payload.ReleaseBranchName }}-docs
21 | |         git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs --force
   | |_________________________________________________________________________________________^ github.event.client_payload.ReleaseBranchName may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_pull_request.yml:17:7
   |
17 |       - name: Clone release branch to create pull request
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
18 | /       run: |
19 | |         git checkout ${{ github.event.client_payload.ReleaseBranchName }}
20 | |         git branch ${{ github.event.client_payload.ReleaseBranchName }}-docs
21 | |         git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs --force
   | |_________________________________________________________________________________________^ github.event.client_payload.ReleaseBranchName may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_pull_request.yml:23:7
   |
23 |       - name: Create pull request for ${{ github.event.client_payload.ReleaseBranchName }}
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
24 |         id: create-pr
...
27 |           github-token: ${{secrets.GITHUB_TOKEN}}
28 | /         script: |
29 | |           let response = await github.rest.pulls.create({
...  |
36 | |           });
37 | |           return response.data.number
   | |_____________________________________^ github.event.client_payload.PullRequestTitle may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_pull_request.yml:23:7
   |
23 |       - name: Create pull request for ${{ github.event.client_payload.ReleaseBranchName }}
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
24 |         id: create-pr
...
27 |           github-token: ${{secrets.GITHUB_TOKEN}}
28 | /         script: |
29 | |           let response = await github.rest.pulls.create({
...  |
36 | |           });
37 | |           return response.data.number
   | |_____________________________________^ github.event.client_payload.ReleaseBranchName may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_pull_request.yml:23:7
   |
23 |       - name: Create pull request for ${{ github.event.client_payload.ReleaseBranchName }}
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
24 |         id: create-pr
...
27 |           github-token: ${{secrets.GITHUB_TOKEN}}
28 | /         script: |
29 | |           let response = await github.rest.pulls.create({
...  |
36 | |           });
37 | |           return response.data.number
   | |_____________________________________^ github.event.client_payload.PullRequestBase may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_pull_request.yml:23:7
   |
23 |       - name: Create pull request for ${{ github.event.client_payload.ReleaseBranchName }}
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
24 |         id: create-pr
...
27 |           github-token: ${{secrets.GITHUB_TOKEN}}
28 | /         script: |
29 | |           let response = await github.rest.pulls.create({
...  |
36 | |           });
37 | |           return response.data.number
   | |_____________________________________^ github.event.client_payload.PullRequestBody may expand into attacker-controllable code
   |
   = note: audit confidence → High

info[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_pull_request.yml:39:7
   |
39 |       - name: Request reviewers
   |         ----------------------- info: this step
40 |         uses: actions/github-script@v7
41 |         with:
42 |           github-token: ${{secrets.PRAPPROVAL_SECRET}}
43 | /         script: |
44 | |           github.rest.pulls.requestReviewers({
...  |
48 | |               team_reviewers: ['runner-images-team']
49 | |           })
   | |_____________- info: steps.create-pr.outputs.result may expand into attacker-controllable code
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/create_sbom_report.yml:1:1
   |
 1 | / name: Create SBOM for the release
 2 | | # Inherited variables:
...  |
92 | |           asset_name: sbom.${{ github.event.client_payload.agentSpec }}.json.zip
93 | |           asset_content_type: application/zip
   | |______________________________________________- default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/create_sbom_report.yml:19:3
   |
19 | /   sbom-check:
20 | |     outputs:
...  |
42 | |         echo "status=okay" >> $env:GITHUB_OUTPUT
43 | |   #Generating SBOM
   | |                  -
   | |__________________|
   |                    this job
   |                    default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/create_sbom_report.yml:44:3
   |
44 | /   building-sbom:
45 | |     needs: sbom-check
...  |
92 | |           asset_name: sbom.${{ github.event.client_payload.agentSpec }}.json.zip
93 | |           asset_content_type: application/zip
   | |                                              -
   | |______________________________________________|
   |                                                this job
   |                                                default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_sbom_report.yml:24:7
   |
24 |       - name: Check release for ${{ github.event.client_payload.ReleaseBranchName }}
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
25 |         id: check
26 |         shell: pwsh
27 | /       run: |
28 | |         $apiUrl = "https://api.github.com/repos/actions/runner-images/releases/${{ github.event.client_payload.ReleaseID }}"
...  |
41 | |         Write-Host "Release has been found, SBOM is not attached, starting generation."
42 | |         echo "status=okay" >> $env:GITHUB_OUTPUT
   | |________________________________________________^ github.event.client_payload.ReleaseID may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_sbom_report.yml:24:7
   |
24 |       - name: Check release for ${{ github.event.client_payload.ReleaseBranchName }}
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
25 |         id: check
26 |         shell: pwsh
27 | /       run: |
28 | |         $apiUrl = "https://api.github.com/repos/actions/runner-images/releases/${{ github.event.client_payload.ReleaseID }}"
...  |
41 | |         Write-Host "Release has been found, SBOM is not attached, starting generation."
42 | |         echo "status=okay" >> $env:GITHUB_OUTPUT
   | |________________________________________________^ github.event.client_payload.ReleaseID may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_sbom_report.yml:24:7
   |
24 |       - name: Check release for ${{ github.event.client_payload.ReleaseBranchName }}
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
25 |         id: check
26 |         shell: pwsh
27 | /       run: |
28 | |         $apiUrl = "https://api.github.com/repos/actions/runner-images/releases/${{ github.event.client_payload.ReleaseID }}"
...  |
41 | |         Write-Host "Release has been found, SBOM is not attached, starting generation."
42 | |         echo "status=okay" >> $env:GITHUB_OUTPUT
   | |________________________________________________^ github.event.client_payload.ReleaseID may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_sbom_report.yml:49:9
   |
49 |         - name: Available image version check for ${{ github.event.client_payload.ReleaseBranchName }}
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
50 | /         run: |
51 | |           $imageVersionComponents = $env:ImageVersion.Split('.')
...  |
55 | |             throw "Current runner $imageMajorVersion.$imageMinorVersion image version doesn't match ${{ github.event.client_payload....
56 | |           }
   | |___________^ github.event.client_payload.imageVersion may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/create_sbom_report.yml:49:9
   |
49 |         - name: Available image version check for ${{ github.event.client_payload.ReleaseBranchName }}
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
50 | /         run: |
51 | |           $imageVersionComponents = $env:ImageVersion.Split('.')
...  |
55 | |             throw "Current runner $imageMajorVersion.$imageMinorVersion image version doesn't match ${{ github.event.client_payload....
56 | |           }
   | |___________^ github.event.client_payload.imageVersion may expand into attacker-controllable code
   |
   = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/linter.yml:19:9
   |
19 |         - name: Checkout Code
   |  _________-
20 | |         uses: actions/checkout@v4
21 | |         with:
22 | |           fetch-depth: 0
   | |________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/linter.yml:14:3
   |
14 | /   build:
15 | |     name: Lint JSON & MD files
...  |
35 | |         run: ./images.CI/shebang-linter.ps1
36 | |         shell: pwsh
   | |                    -
   | |____________________|
   |                      this job
   |                      default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/merge_pull_request.yml:13:7
   |
13 |       - uses: actions/checkout@v4
   |  _______-
14 | |       with:
15 | |         fetch-depth: 0
   | |______________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/merge_pull_request.yml:9:3
   |
 9 | /   Merge_pull_request:
10 | |     runs-on: ubuntu-latest
...  |
47 | |             merge_method: "squash"
48 | |           })
   | |             -
   | |_____________|
   |               this job
   |               default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/merge_pull_request.yml:17:7
   |
17 |       - name: Resolve possible conflicts ${{ github.event.client_payload.ReleaseBranchName }} with main
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
18 | /       run: |
19 | |         git config --global user.email "no-reply@github.com"
...  |
23 | |         git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs
24 | |         sleep 30
   | |________________^ github.event.client_payload.ReleaseBranchName may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/merge_pull_request.yml:17:7
   |
17 |       - name: Resolve possible conflicts ${{ github.event.client_payload.ReleaseBranchName }} with main
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
18 | /       run: |
19 | |         git config --global user.email "no-reply@github.com"
...  |
23 | |         git push origin ${{ github.event.client_payload.ReleaseBranchName }}-docs
24 | |         sleep 30
   | |________________^ github.event.client_payload.ReleaseBranchName may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/merge_pull_request.yml:26:7
   |
26 |       - name: Approve pull request by GitHub-Actions bot
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
27 |         uses: actions/github-script@v7
28 |         with:
29 |           github-token: ${{secrets.PRAPPROVAL_SECRET}}
30 | /         script: |
31 | |           github.rest.pulls.createReview({
...  |
35 | |             event: "APPROVE"
36 | |           });
   | |_____________^ github.event.client_payload.PullRequestNumber may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/merge_pull_request.yml:38:7
   |
38 |       - name: Merge pull request for ${{ github.event.client_payload.ReleaseBranchName }}
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
39 |         uses: actions/github-script@v7
40 |         with:
41 |           github-token: ${{secrets.GITHUB_TOKEN}}
42 | /         script: |
43 | |           github.rest.pulls.merge({
...  |
47 | |             merge_method: "squash"
48 | |           })
   | |_____________^ github.event.client_payload.PullRequestNumber may expand into attacker-controllable code
   |
   = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/packer-build-and-publish.yml:17:9
   |
17 |         - name: Checkout main branch
   |  _________-
18 | |         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
19 | |         with:
20 | |           ref: main
   | |___________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/packer-build-and-publish.yml:38:9
   |
38 |         - name: Checkout code
   |  _________-
39 | |         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
   | |________________________________________________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/packer-build-and-publish.yml:105:9
    |
105 |         - name: Checkout repository
    |  _________-
106 | |         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
    | |________________________________________________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/packer-build-and-publish.yml:215:9
    |
215 |         - name: Checkout repository
    |  _________-
216 | |         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
217 | |
218 | |       # If no release exists, download artifacts from the build job
    | |___________________________________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low

warning[artipacked]: credential persistence through GitHub Actions artifacts
   --> ./.github/workflows/packer-build-and-publish.yml:288:9
    |
288 |         - name: Checkout code
    |  _________-
289 | |         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
    | |________________________________________________________________________________- does not set persist-credentials: false
    |
    = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/packer-build-and-publish.yml:41:9
   |
41 |         - name: Find release for the commit
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
42 |           id: get_release_by_commit
43 | /         run: |
44 | |           # Fetch last 100 releases (it sorts by latest, last 100 should be enough)
...  |
84 | |           echo "No release found for commit ${{ github.sha }}"
85 | |           echo "release_found=false" >> $GITHUB_OUTPUT
   | |______________________________________________________^ github.api_url may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/packer-build-and-publish.yml:41:9
   |
41 |         - name: Find release for the commit
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
42 |           id: get_release_by_commit
43 | /         run: |
44 | |           # Fetch last 100 releases (it sorts by latest, last 100 should be enough)
...  |
84 | |           echo "No release found for commit ${{ github.sha }}"
85 | |           echo "release_found=false" >> $GITHUB_OUTPUT
   | |______________________________________________________^ github.api_url may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:168:9
    |
168 |         - name: Packer build
    |           ^^^^^^^^^^^^^^^^^^ this step
169 |           env:
...
172 |             GITHUB_REPOSITORY_NAME: ${{ steps.auth.outputs.repository_name }}
173 | /         run: |
174 | |           packer init ${{ matrix.template }}
...   |
180 | |             -var aws_assume_role_session_name=GitHubActions \
181 | |             ${{ matrix.template }}
    | |__________________________________^ github.ref_name may expand into attacker-controllable code
    |
    = note: audit confidence → High

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:225:9
    |
225 |         - name: Check if latest
    |           ^^^^^^^^^^^^^^^^^^^^^ this step
226 |           id: is_latest
227 | /         run: |
228 | |           # Fetch all tags from the repository
...   |
241 | |               echo "value=false" >> "${GITHUB_OUTPUT}"
242 | |           fi
    | |____________^ github.ref_name may expand into attacker-controllable code
    |
    = note: audit confidence → High

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:256:9
    |
256 |         - name: Update release
    |           ^^^^^^^^^^^^^^^^^^^^ this step
257 |           id: update_release
...
261 |             RELEASE_TAG: ${{ needs.check-release.outputs.tag }}
262 | /         run: |
263 | |           curl -X PATCH \
...   |
273 | |               '{name: $name, tag_name: $tag_name, draft: $draft, make_latest: $make_latest, body: $body}' \
274 | |             )"
    | |______________^ github.api_url may expand into attacker-controllable code
    |
    = note: audit confidence → High

info[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:256:9
    |
256 |         - name: Update release
    |           -------------------- info: this step
257 |           id: update_release
...
261 |             RELEASE_TAG: ${{ needs.check-release.outputs.tag }}
262 | /         run: |
263 | |           curl -X PATCH \
...   |
273 | |               '{name: $name, tag_name: $tag_name, draft: $draft, make_latest: $make_latest, body: $body}' \
274 | |             )"
    | |______________- info: needs.check-release.outputs.release_id may expand into attacker-controllable code
    |
    = note: audit confidence → Low

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:256:9
    |
256 |         - name: Update release
    |           ^^^^^^^^^^^^^^^^^^^^ this step
257 |           id: update_release
...
261 |             RELEASE_TAG: ${{ needs.check-release.outputs.tag }}
262 | /         run: |
263 | |           curl -X PATCH \
...   |
273 | |               '{name: $name, tag_name: $tag_name, draft: $draft, make_latest: $make_latest, body: $body}' \
274 | |             )"
    | |______________^ github.ref_name may expand into attacker-controllable code
    |
    = note: audit confidence → High

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:256:9
    |
256 |         - name: Update release
    |           ^^^^^^^^^^^^^^^^^^^^ this step
257 |           id: update_release
...
261 |             RELEASE_TAG: ${{ needs.check-release.outputs.tag }}
262 | /         run: |
263 | |           curl -X PATCH \
...   |
273 | |               '{name: $name, tag_name: $tag_name, draft: $draft, make_latest: $make_latest, body: $body}' \
274 | |             )"
    | |______________^ github.ref_name may expand into attacker-controllable code
    |
    = note: audit confidence → High

info[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:256:9
    |
256 |         - name: Update release
    |           -------------------- info: this step
257 |           id: update_release
...
261 |             RELEASE_TAG: ${{ needs.check-release.outputs.tag }}
262 | /         run: |
263 | |           curl -X PATCH \
...   |
273 | |               '{name: $name, tag_name: $tag_name, draft: $draft, make_latest: $make_latest, body: $body}' \
274 | |             )"
    | |______________- info: steps.is_latest.outputs.value may expand into attacker-controllable code
    |
    = note: audit confidence → Low

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:256:9
    |
256 |         - name: Update release
    |           ^^^^^^^^^^^^^^^^^^^^ this step
257 |           id: update_release
...
261 |             RELEASE_TAG: ${{ needs.check-release.outputs.tag }}
262 | /         run: |
263 | |           curl -X PATCH \
...   |
273 | |               '{name: $name, tag_name: $tag_name, draft: $draft, make_latest: $make_latest, body: $body}' \
274 | |             )"
    | |______________^ github.ref_name may expand into attacker-controllable code
    |
    = note: audit confidence → High

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:256:9
    |
256 |         - name: Update release
    |           ^^^^^^^^^^^^^^^^^^^^ this step
257 |           id: update_release
...
261 |             RELEASE_TAG: ${{ needs.check-release.outputs.tag }}
262 | /         run: |
263 | |           curl -X PATCH \
...   |
273 | |               '{name: $name, tag_name: $tag_name, draft: $draft, make_latest: $make_latest, body: $body}' \
274 | |             )"
    | |______________^ github.ref_name may expand into attacker-controllable code
    |
    = note: audit confidence → High

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:291:9
    |
291 |         - name: Download manifest assets
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
292 | /         run: |
293 | |           # Get the list of assets for the specified release
...   |
303 | |               -o "${asset_name}"
304 | |           done
    | |______________^ github.api_url may expand into attacker-controllable code
    |
    = note: audit confidence → High

info[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:291:9
    |
291 |         - name: Download manifest assets
    |           ------------------------------ info: this step
292 | /         run: |
293 | |           # Get the list of assets for the specified release
...   |
303 | |               -o "${asset_name}"
304 | |           done
    | |______________- info: needs.publish.outputs.release_id may expand into attacker-controllable code
    |
    = note: audit confidence → Low

error[template-injection]: code injection via template expansion
   --> ./.github/workflows/packer-build-and-publish.yml:291:9
    |
291 |         - name: Download manifest assets
    |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
292 | /         run: |
293 | |           # Get the list of assets for the specified release
...   |
303 | |               -o "${asset_name}"
304 | |           done
    | |______________^ github.api_url may expand into attacker-controllable code
    |
    = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/packer-build-and-publish.yml:307:9
    |
307 |         uses: grafana/shared-workflows/actions/aws-auth@main
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

error[unpinned-uses]: unpinned action reference
   --> ./.github/workflows/packer-build-and-publish.yml:341:9
    |
341 |         uses: grafana/shared-workflows/actions/aws-auth@main
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
    |
    = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/powershell-tests.yml:17:9
   |
17 |         - name: Checkout Repository
   |  _________-
18 | |         uses: actions/checkout@v4
   | |_________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/powershell-tests.yml:12:3
   |
12 | /   powershell-tests:
13 | |     name: PowerShell tests
...  |
24 | |             Invoke-Pester -Output Detailed "helpers/software-report-base/tests"
25 | |         
   | |        -
   | |________|
   |          this job
   |          default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/sync-upstream-change.yml:34:9
   |
34 |         - name: Checkout the repository
   |  _________-
35 | |         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
...  |
38 | |           ref: ${{ github.event.pull_request.head.ref }}
39 | |           token: ${{ steps.generate-token.outputs.token }}
   | |__________________________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/sync-upstream-change.yml:59:9
   |
59 |         - name: Push changes to branch
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
60 | /         run: |
61 | |           git push -f origin ${{ github.event.pull_request.head.ref }}
   | |______________________________________________________________________^ github.event.pull_request.head.ref may expand into attacker-controllable code
   |
   = note: audit confidence → High

info[template-injection]: code injection via template expansion
  --> ./.github/workflows/sync-upstream-change.yml:63:9
   |
63 |         - name: Set PR body
   |           ----------------- info: this step
64 |           id: pr-body
...
72 |             PR_BODY_WITH_CONFLICTS_TEMPLATE: ".github/workflows/sync-upstream/templates/pr-body-with-conflicts.txt"
73 | /         run: |
74 | |           echo 'body<<EOF' >> $GITHUB_OUTPUT
...  |
79 | |           fi
80 | |           echo EOF >> $GITHUB_OUTPUT
   | |____________________________________- info: steps.merge.outputs.conflicts may expand into attacker-controllable code
   |
   = note: audit confidence → Low

info[template-injection]: code injection via template expansion
  --> ./.github/workflows/sync-upstream-change.yml:82:9
   |
82 |         - name: Edit pull request
   |           ----------------------- info: this step
83 |           env:
84 |             GH_TOKEN: ${{ github.token }}
85 | /         run: |
86 | |           gh pr edit sync-upstream-${{ github.run_number }} \
87 | |           --repo ${{ github.repository }} \
88 | |           --body '${{ steps.pr-body.outputs.body }}'
   | |_____________________________________________________- info: steps.pr-body.outputs.body may expand into attacker-controllable code
   |
   = note: audit confidence → Low

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/sync-upstream-change.yml:21:9
   |
21 |         uses: grafana/shared-workflows/actions/get-vault-secrets@main
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/sync-upstream-create.yml:31:9
   |
31 |         - name: Checkout the repository
   |  _________-
32 | |         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
...  |
35 | |           ref: main
36 | |           token: ${{ steps.generate-token.outputs.token }}
   | |__________________________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

info[template-injection]: code injection via template expansion
  --> ./.github/workflows/sync-upstream-create.yml:68:9
   |
68 |         - name: Set PR body
   |           ----------------- info: this step
69 |           id: pr-body
...
77 |             PR_BODY_WITH_CONFLICTS_TEMPLATE: ".github/workflows/sync-upstream/templates/pr-body-with-conflicts.txt"
78 | /         run: |
79 | |           echo 'body<<EOF' >> $GITHUB_OUTPUT
...  |
84 | |           fi
85 | |           echo EOF >> $GITHUB_OUTPUT
   | |____________________________________- info: steps.merge.outputs.conflicts may expand into attacker-controllable code
   |
   = note: audit confidence → Low

info[template-injection]: code injection via template expansion
  --> ./.github/workflows/sync-upstream-create.yml:87:9
   |
87 |         - name: Create pull request
   |           ------------------------- info: this step
88 |           env:
89 |             GH_TOKEN: ${{ github.token }}
90 | /         run: |
91 | |           gh pr create --title 'Update from upstream' \
...  |
97 | |           --repo ${{ github.repository }} \
98 | |           --body '${{ steps.pr-body.outputs.body }}'
   | |_____________________________________________________- info: steps.pr-body.outputs.body may expand into attacker-controllable code
   |
   = note: audit confidence → Low

info[template-injection]: code injection via template expansion
  --> ./.github/workflows/sync-upstream-create.yml:87:9
   |
87 |         - name: Create pull request
   |           ------------------------- info: this step
88 |           env:
89 |             GH_TOKEN: ${{ github.token }}
90 | /         run: |
91 | |           gh pr create --title 'Update from upstream' \
...  |
97 | |           --repo ${{ github.repository }} \
98 | |           --body '${{ steps.pr-body.outputs.body }}'
   | |_____________________________________________________- info: steps.pr-body.outputs.body may expand into attacker-controllable code
   |
   = note: audit confidence → Low

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/sync-upstream-create.yml:18:9
   |
18 |         uses: grafana/shared-workflows/actions/get-vault-secrets@main
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/sync-upstream-merge.yml:34:9
   |
34 |         - name: Checkout the repository
   |  _________-
35 | |         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
...  |
38 | |           ref: ${{ github.event.pull_request.head.ref }}
39 | |           token: ${{ steps.generate-token.outputs.token }}
   | |__________________________________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/sync-upstream-merge.yml:54:9
   |
54 |         - name: Delete branch on success
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
55 |           if: ${{ success() }}
56 | /         run: |
57 | |           git push -d origin ${{ github.event.pull_request.head.ref }}
   | |______________________________________________________________________^ github.event.pull_request.head.ref may expand into attacker-controllable code
   |
   = note: audit confidence → High

info[template-injection]: code injection via template expansion
  --> ./.github/workflows/sync-upstream-merge.yml:59:9
   |
59 |         - name: Comment error on failure
   |           ------------------------------ info: this step
60 |           if: ${{ failure() }}
61 |           env:
62 |             GH_TOKEN: ${{ github.token }}
63 | /         run: |
64 | |           gh pr comment ${{ github.event.pull_request.number }} --body 'Failed to push changes to main.
...  |
68 | |           ${{ steps.push.outputs.output }}
69 | |           ```'
   | |_______________- info: steps.push.outputs.output may expand into attacker-controllable code
   |
   = note: audit confidence → Low

error[unpinned-uses]: unpinned action reference
  --> ./.github/workflows/sync-upstream-merge.yml:21:9
   |
21 |         uses: grafana/shared-workflows/actions/get-vault-secrets@main
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ action is not pinned to a hash (required by blanket policy)
   |
   = note: audit confidence → High

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/tag-build-and-publish.yml:9:3
   |
 9 | /   build-and-publish:
10 | |     uses: grafana/runner-images/.github/workflows/packer-build-and-publish.yml@main
   | |                                                                                    -
   | |____________________________________________________________________________________|
   |                                                                                      this job
   |                                                                                      default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/trigger-ubuntu-win-build.yml:18:9
   |
18 |         - name: Trigger Build workflow
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
19 |           env:
...
22 |             CI_PR: ${{ secrets.CI_REPO }}
23 | /         run: |
24 | |           $headers = @{
...  |
46 | |             throw "$($_.exception[0].message)"
47 | |           }
   | |____________^ inputs.image_type may expand into attacker-controllable code
   |
   = note: audit confidence → Low

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/trigger-ubuntu-win-build.yml:18:9
   |
18 |         - name: Trigger Build workflow
   |           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
19 |           env:
...
22 |             CI_PR: ${{ secrets.CI_REPO }}
23 | /         run: |
24 | |           $headers = @{
...  |
46 | |             throw "$($_.exception[0].message)"
47 | |           }
   | |____________^ github.event.pull_request.head.repo.full_name may expand into attacker-controllable code
   |
   = note: audit confidence → High

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/ubuntu2004.yml:15:3
   |
15 | /   Ubuntu_2004:
16 | |     if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2004'
...  |
19 | |       image_type: 'ubuntu2004'
20 | |     secrets: inherit
   | |                     -
   | |_____________________|
   |                       this job
   |                       default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> ./.github/workflows/ubuntu2004.yml:4:1
  |
4 | / on:
5 | |   pull_request_target:
6 | |     types: labeled
7 | |     paths:
8 | |     - 'images/ubuntu/**'
  | |________________________^ pull_request_target is almost always used insecurely
  |
  = note: audit confidence → Medium

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/ubuntu2004.yml:17:5
   |
17 |     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
   |     ------------------------------------------------------ this reusable workflow
18 |     with:
19 |       image_type: 'ubuntu2004'
20 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/ubuntu2204.yml:15:3
   |
15 | /   Ubuntu_2204:
16 | |     if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2204'
...  |
19 | |       image_type: 'ubuntu2204'
20 | |     secrets: inherit
   | |                     -
   | |_____________________|
   |                       this job
   |                       default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> ./.github/workflows/ubuntu2204.yml:4:1
  |
4 | / on:
5 | |   pull_request_target:
6 | |     types: labeled
7 | |     paths:
8 | |     - 'images/ubuntu/**'
  | |________________________^ pull_request_target is almost always used insecurely
  |
  = note: audit confidence → Medium

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/ubuntu2204.yml:17:5
   |
17 |     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
   |     ------------------------------------------------------ this reusable workflow
18 |     with:
19 |       image_type: 'ubuntu2204'
20 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/ubuntu2404.yml:15:3
   |
15 | /   Ubuntu_2404:
16 | |     if: github.event.label.name == 'CI ubuntu-all' || github.event.label.name == 'CI ubuntu-2404'
...  |
19 | |       image_type: 'ubuntu2404'
20 | |     secrets: inherit
   | |                     -
   | |_____________________|
   |                       this job
   |                       default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> ./.github/workflows/ubuntu2404.yml:4:1
  |
4 | / on:
5 | |   pull_request_target:
6 | |     types: labeled
7 | |     paths:
8 | |     - 'images/ubuntu/**'
  | |________________________^ pull_request_target is almost always used insecurely
  |
  = note: audit confidence → Medium

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/ubuntu2404.yml:17:5
   |
17 |     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
   |     ------------------------------------------------------ this reusable workflow
18 |     with:
19 |       image_type: 'ubuntu2404'
20 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/update_github_release.yml:13:7
   |
13 |     - uses: actions/checkout@v4
   |       ------------------------- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/update_github_release.yml:9:3
   |
 9 | /   Update_GitHub_release:
10 | |     runs-on: ubuntu-latest
...  |
29 | |               prerelease: ${{ github.event.client_payload.Prerelease }}
30 | |             });
   | |                -
   | |________________|
   |                  this job
   |                  default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/update_github_release.yml:15:7
   |
15 |       - name: Update release for ${{ github.event.client_payload.ReleaseBranchName }}
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
16 |         uses: actions/github-script@v7
17 |         with:
18 |           github-token: ${{secrets.GITHUB_TOKEN}}
19 | /         script: |
20 | |             const response = await github.rest.repos.getReleaseByTag({
...  |
29 | |               prerelease: ${{ github.event.client_payload.Prerelease }}
30 | |             });
   | |________________^ github.event.client_payload.ReleaseBranchName may expand into attacker-controllable code
   |
   = note: audit confidence → High

error[template-injection]: code injection via template expansion
  --> ./.github/workflows/update_github_release.yml:15:7
   |
15 |       - name: Update release for ${{ github.event.client_payload.ReleaseBranchName }}
   |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this step
16 |         uses: actions/github-script@v7
17 |         with:
18 |           github-token: ${{secrets.GITHUB_TOKEN}}
19 | /         script: |
20 | |             const response = await github.rest.repos.getReleaseByTag({
...  |
29 | |               prerelease: ${{ github.event.client_payload.Prerelease }}
30 | |             });
   | |________________^ github.event.client_payload.Prerelease may expand into attacker-controllable code
   |
   = note: audit confidence → High

warning[artipacked]: credential persistence through GitHub Actions artifacts
  --> ./.github/workflows/validate-json-schema.yml:15:9
   |
15 |         - name: Checkout repository
   |  _________-
16 | |         uses: actions/checkout@v3
   | |_________________________________- does not set persist-credentials: false
   |
   = note: audit confidence → Low

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/validate-json-schema.yml:12:3
   |
12 | /   validate-json-schema:
13 | |     runs-on: ubuntu-latest
...  |
19 | |         shell: pwsh
20 | |         run: ./helpers/CheckJsonSchema.ps1
   | |                                           -
   | |___________________________________________|
   |                                             this job
   |                                             default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/windows2019.yml:15:3
   |
15 | /   Windows_2019:
16 | |     if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-2019'
...  |
19 | |       image_type: 'windows2019'
20 | |     secrets: inherit
   | |                     -
   | |_____________________|
   |                       this job
   |                       default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> ./.github/workflows/windows2019.yml:4:1
  |
4 | / on:
5 | |   pull_request_target:
6 | |     types: labeled
7 | |     paths:
8 | |     - 'images/windows/**'
  | |_________________________^ pull_request_target is almost always used insecurely
  |
  = note: audit confidence → Medium

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/windows2019.yml:17:5
   |
17 |     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
   |     ------------------------------------------------------ this reusable workflow
18 |     with:
19 |       image_type: 'windows2019'
20 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/windows2022.yml:15:3
   |
15 | /   Windows_2022:
16 | |     if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-2022'
...  |
19 | |       image_type: 'windows2022'
20 | |     secrets: inherit
   | |                     -
   | |_____________________|
   |                       this job
   |                       default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> ./.github/workflows/windows2022.yml:4:1
  |
4 | / on:
5 | |   pull_request_target:
6 | |     types: labeled
7 | |     paths:
8 | |     - 'images/windows/**'
  | |_________________________^ pull_request_target is almost always used insecurely
  |
  = note: audit confidence → Medium

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/windows2022.yml:17:5
   |
17 |     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
   |     ------------------------------------------------------ this reusable workflow
18 |     with:
19 |       image_type: 'windows2022'
20 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

warning[excessive-permissions]: overly broad permissions
  --> ./.github/workflows/windows2025.yml:15:3
   |
15 | /   Windows_2022:
16 | |     if: github.event.label.name == 'CI windows-all' || github.event.label.name == 'CI windows-2025'
...  |
19 | |       image_type: 'windows2025'
20 | |     secrets: inherit
   | |                     -
   | |_____________________|
   |                       this job
   |                       default permissions used due to no permissions: block
   |
   = note: audit confidence → Medium

error[dangerous-triggers]: use of fundamentally insecure workflow trigger
 --> ./.github/workflows/windows2025.yml:4:1
  |
4 | / on:
5 | |   pull_request_target:
6 | |     types: labeled
7 | |     paths:
8 | |     - 'images/windows/**'
  | |_________________________^ pull_request_target is almost always used insecurely
  |
  = note: audit confidence → Medium

warning[secrets-inherit]: secrets unconditionally inherited by called workflow
  --> ./.github/workflows/windows2025.yml:17:5
   |
17 |     uses: ./.github/workflows/trigger-ubuntu-win-build.yml
   |     ------------------------------------------------------ this reusable workflow
18 |     with:
19 |       image_type: 'windows2025'
20 |     secrets: inherit
   |     ---------------- inherits all parent secrets
   |
   = note: audit confidence → High

126 findings (30 suppressed): 0 unknown, 11 informational, 0 low, 40 medium, 45 high
```

</details>