### PR TITLE
Persist credentials on sync upstream workflows

### DIFF
--- a/.github/workflows/sync-upstream-change.yml
+++ b/.github/workflows/sync-upstream-change.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.generate-token.outputs.token }}
-          persist-credentials: false
+          persist-credentials: true # This is required to push to the repository
 
       - name: Reset branch to main
         run: |

--- a/.github/workflows/sync-upstream-create.yml
+++ b/.github/workflows/sync-upstream-create.yml
@@ -34,7 +34,7 @@ jobs:
           fetch-depth: 0
           ref: main
           token: ${{ steps.generate-token.outputs.token }}
-          persist-credentials: false
+          persist-credentials: true # This is required to push to the repository
 
       - name: Create new branch from main
         run: |

--- a/.github/workflows/sync-upstream-merge.yml
+++ b/.github/workflows/sync-upstream-merge.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
           token: ${{ steps.generate-token.outputs.token }}
-          persist-credentials: false
+          persist-credentials: true # This is required to push to the repository
 
       - name: Configure Git
         run: |


### PR DESCRIPTION
This fixes `fatal: could not read Username for 'https://github.com': No such device or address` on push operations of the sync upstream workflows.

Error run: https://github.com/grafana/runner-images/actions/runs/14841375569

Fixed run with workflow dispatch on this branch: https://github.com/grafana/runner-images/actions/runs/14841423172