### PR TITLE
Handle merge conflicts on sync upstream bot change command

### DIFF
--- a/.github/workflows/sync-upstream-change.yml
+++ b/.github/workflows/sync-upstream-change.yml
@@ -55,7 +55,15 @@ jobs:
           git fetch upstream
           SHA="$(git rev-parse upstream/main)"
           echo "upstream-sha=$SHA" >> $GITHUB_OUTPUT
-          git merge $SHA || echo "conflicts=true" >> $GITHUB_OUTPUT
+          if ! git merge -m "Merge commit '$SHA' from actions/runner-images" "${SHA}"; then
+            echo "conflicts=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Handle conflicts with empty commit
+        if: steps.merge.outputs.conflicts == 'true'
+        run: |
+          git merge --abort
+          git commit --allow-empty -m "Empty commit due to merge conflicts"
 
       - name: Push changes to branch
         env:


### PR DESCRIPTION
When a PR such as https://github.com/grafana/runner-images/pull/154 has conflicts and you execute the `bot change` command the workflow fails to merge and pushes the code from the `main` branch to the PR branch, effectively closing the PR.

This will handle conflicts with an empty commit, similarly to how the sync-upstream-create workflow does.