### PR TITLE
Give permissions to job

### DIFF
--- a/.github/workflows/tag-build-and-publish.yml
+++ b/.github/workflows/tag-build-and-publish.yml
@@ -10,4 +10,7 @@ permissions:
 
 jobs:
   build-and-publish:
+    permissions:
+      contents: write
+      id-token: write
     uses: grafana/runner-images/.github/workflows/packer-build-and-publish.yml@main


### PR DESCRIPTION
## Description

We are explicitly setting content permissions to be `read` while the called action needs contents and id-token write permissions. We are setting the permissions on the job level to make sure we don't give overly broad permissions to the whole workflow.

![image](https://github.com/user-attachments/assets/87eaa274-ac51-49b9-bb4f-bc5d6f64db5d)
