### PR TITLE
Remove Test-IsUbuntu20 flag

### DIFF
--- a/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
+++ b/images/ubuntu/scripts/docs-gen/Generate-SoftwareReport.ps1
@@ -98,7 +98,7 @@ if (Test-IsUbuntu22) {
 # Tools
 $tools = $installedSoftware.AddHeader("Tools")
 $tools.AddToolVersion("Ansible", $(Get-AnsibleVersion))
-if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
+if (Test-IsUbuntu22) {
     # TODO: Fix retrieval of apt-fast version on Software Report
     # $tools.AddToolVersion("apt-fast", $(Get-AptFastVersion))
 }
@@ -122,7 +122,7 @@ $tools.AddToolVersion("Git LFS", $(Get-GitLFSVersion))
 $tools.AddToolVersion("Git-ftp", $(Get-GitFTPVersion))
 $tools.AddToolVersion("Haveged", $(Get-HavegedVersion))
 if (Test-IsAmd64) {
-    if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
+    if (Test-IsUbuntu22) {
         $tools.AddToolVersion("Heroku", $(Get-HerokuVersion))
     }
 }
@@ -145,7 +145,7 @@ $tools.AddToolVersion("Parcel", $(Get-ParcelVersion))
 $tools.AddToolVersion("Podman", $(Get-PodManVersion))
 $tools.AddToolVersion("Pulumi", $(Get-PulumiVersion))
 if (Test-IsAmd64) {
-    if ((Test-IsUbuntu20) -or (Test-IsUbuntu22)) {
+    if (Test-IsUbuntu22) {
         $tools.AddToolVersion("R", $(Get-RVersion))
     }
 }

--- a/images/ubuntu/scripts/tests/Tools.Tests.ps1
+++ b/images/ubuntu/scripts/tests/Tools.Tests.ps1
@@ -190,13 +190,13 @@ Describe "MSSQLCommandLineTools" -Skip:((-not (Test-IsUbuntu22))) {
     }
 }
 
-Describe "SqlPackage" -Skip:((-not (Test-IsAmd64)) -or ((-not (Test-IsUbuntu20)) -and (-not (Test-IsUbuntu22)))) {
+Describe "SqlPackage" -Skip:((-not (Test-IsAmd64)) -or (-not (Test-IsUbuntu22))) {
     It "sqlpackage" {
         "sqlpackage /version" | Should -ReturnZeroExitCode
     }
 }
 
-Describe "R" -Skip:((-not (Test-IsAmd64)) -or ((-not (Test-IsUbuntu20)) -and (-not (Test-IsUbuntu22)))) {
+Describe "R" -Skip:((-not (Test-IsAmd64)) -or (-not (Test-IsUbuntu22))) {
     It "r" {
         "R --version" | Should -ReturnZeroExitCode
     }
@@ -253,13 +253,13 @@ Describe "Git-lfs" {
     }
 }
 
-Describe "Heroku" -Skip:((-not (Test-IsAmd64)) -or ((-not (Test-IsUbuntu20)) -and (-not (Test-IsUbuntu22)))) {
+Describe "Heroku" -Skip:((-not (Test-IsAmd64)) -or (-not (Test-IsUbuntu22))) {
     It "heroku" {
         "heroku --version" | Should -ReturnZeroExitCode
     }
 }
 
-Describe "HHVM" -Skip:(-not (Test-IsUbuntu20)) {
+Describe "HHVM" {
     It "hhvm" {
         "hhvm --version" | Should -ReturnZeroExitCode
     }


### PR DESCRIPTION
# Description

Removes a flag which didn't get removed after merging upstream to main.

[Fails this workflow](https://github.com/grafana/runner-images/actions/runs/14994566588/attempts/1).