### PR TITLE
bug: fix json obj in image-tests action

### DIFF
--- a/.github/actions/image-tests/action.yml
+++ b/.github/actions/image-tests/action.yml
@@ -114,7 +114,7 @@ runs:
         check_result "hashFiles (empty)" "$HASH_FILES_EMPTY" ""
         check_result "fromJSON" "$FROM_JSON_TEST" "value"
         check_result "toJSON" "$TO_JSON_TEST" '{
-          key: value
+          "key": "value"
         }'
 
         # Calculate total test time


### PR DESCRIPTION
After zizmor fixes in [this PR](https://github.com/grafana/runner-images/pull/151), some formatting is now broken and tests fail.

Adding quotes in the `toJSON` validation to match the yaml formatting.