### PR TITLE
Prevent prod releases without dev releases

### DIFF
--- a/.github/workflows/packer-build-and-publish.yml
+++ b/.github/workflows/packer-build-and-publish.yml
@@ -228,7 +228,7 @@ jobs:
       release_id: ${{ steps.publish.outputs.id || needs.check-release.outputs.release_id }}
       prod_release: ${{ env.PROD_RELEASE }}
     env:
-      PROD_RELEASE: ${{ needs.check-main.outputs.is_main == 'true' && !contains(github.ref_name, '-') }}
+      PROD_RELEASE: ${{ needs.check-release.outputs.release_found == 'true' && needs.check-main.outputs.is_main == 'true' && !contains(github.ref_name, '-') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7


### PR DESCRIPTION
This pull request updates the logic for determining the `PROD_RELEASE` environment variable in the GitHub Actions workflow file `.github/workflows/packer-build-and-publish.yml`. The change ensures that a production release is only marked as true if a dev release is found and the branch is the main branch.

Key change:

* [`.github/workflows/packer-build-and-publish.yml`](diffhunk://#diff-b25f077650d449fa54c500cede15db5fdce1ae98f0a436829dbb07da138a2a0dL231-R231): Updated the `PROD_RELEASE` environment variable to include an additional condition (`needs.check-release.outputs.release_found == 'true'`) to verify that a release has been found before marking it as a production release.