### PR TITLE
Update Maven to 3.9.11

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -64,7 +64,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.9.10"
+        "maven": "3.9.11"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -67,7 +67,7 @@
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17", "21"],
-        "maven": "3.9.10"
+        "maven": "3.9.11"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
Maven 3.9.10 was removed from the CDN.

`https://dlcdn.apache.org/maven/maven-3/3.9.10/binaries/apache-maven-3.9.10-bin.zip` doesn't exist, but `https://dlcdn.apache.org/maven/maven-3/3.9.11/binaries/apache-maven-3.9.11-bin.zip` does.

Check https://dlcdn.apache.org/maven/maven-3