### PR TITLE
Use app token to comment error on failure of sync-upstream-merge

### DIFF
--- a/.github/workflows/sync-upstream-merge.yml
+++ b/.github/workflows/sync-upstream-merge.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Comment error on failure
         if: ${{ failure() }}
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PUSH_OUTPUT: ${{ steps.push.outputs.output }}
         run: |


### PR DESCRIPTION
GitHub Actions is failing to comment on PR.