### PR TITLE
Fix tag-build-and-publish to use main instead of sync branch

### DIFF
--- a/.github/workflows/tag-build-and-publish.yml
+++ b/.github/workflows/tag-build-and-publish.yml
@@ -13,4 +13,4 @@ jobs:
     permissions:
       contents: write
       id-token: write
-    uses: grafana/runner-images/.github/workflows/packer-build-and-publish.yml@sync-upstream-b15aef1c
+    uses: grafana/runner-images/.github/workflows/packer-build-and-publish.yml@main


### PR DESCRIPTION
This was changed due to large changes on last merge commit for testing and wasn't reverted back before the PR was merged.