### PR TITLE
fix: Update maven usage manually from 3.9.12 to 3.9.14

### DIFF
--- a/images/ubuntu/toolsets/toolset-2204.json
+++ b/images/ubuntu/toolsets/toolset-2204.json
@@ -67,7 +67,7 @@
     "java": {
         "default": "11",
         "versions": [ "8", "11", "17", "21", "25"],
-        "maven": "3.9.12"
+        "maven": "3.9.14"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-9477386_latest.zip",

--- a/images/ubuntu/toolsets/toolset-2404.json
+++ b/images/ubuntu/toolsets/toolset-2404.json
@@ -71,7 +71,7 @@
     "java": {
         "default": "17",
         "versions": [ "8", "11", "17", "21", "25"],
-        "maven": "3.9.12"
+        "maven": "3.9.14"
     },
     "android": {
         "cmdline-tools": "commandlinetools-linux-11076708_latest.zip",


### PR DESCRIPTION
[Build and publish](https://github.com/grafana/runner-images/actions/workflows/tag-build-and-publish.yml) is failing due a 404 against maven:
```
==> ubuntu24.amazon-ebs.build_image: Downloading package from https://dlcdn.apache.org/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.zip to /tmp/apache-maven-3.9.12-bin.zip...
==> ubuntu24.amazon-ebs.build_image: Received HTTP status code 404 after 0 seconds
```

@guicaulada I'm proposing we can manually bump to an available version as i understand 3.9.12 to be unavailable
