### PR TITLE
fix(ubuntu): skip read_ahead_kb test when no sd* devices

### DIFF
--- a/images/ubuntu/scripts/tests/System.Tests.ps1
+++ b/images/ubuntu/scripts/tests/System.Tests.ps1
@@ -37,7 +37,10 @@ Describe "ReadAhead udev rule" -Skip:(-not (Test-IsUbuntu24)) {
 
     It "All sd* devices have read_ahead_kb set to 128" {
         $devices = Get-ChildItem "/sys/block/sd*/queue/read_ahead_kb" -ErrorAction SilentlyContinue
-        $devices | Should -Not -BeNullOrEmpty -Because "there should be at least one sd* block device"
+        if ($null -eq $devices -or $devices.Count -eq 0) {
+            Set-ItResult -Skipped -Because "no sd* block devices on this platform (e.g. AWS EC2 presents EBS volumes as nvme*/xvd*)"
+            return
+        }
         foreach ($dev in $devices) {
             $value = (Get-Content $dev.FullName).Trim()
             $value | Should -Be "128" -Because "read_ahead_kb for $($dev.FullName) should be 128 to prevent I/O thrashing"


### PR DESCRIPTION
Upstream [actions/runner-images#13938](https://github.com/actions/runner-images/pull/13938) added a `ReadAhead udev rule` Pester test block in [`images/ubuntu/scripts/tests/System.Tests.ps1`](https://github.com/grafana/runner-images/blob/main/images/ubuntu/scripts/tests/System.Tests.ps1#L26-L46) to verify a kernel 6.17 fix on Azure VMs ([actions/runner-images#13770](https://github.com/actions/runner-images/issues/13770), [ravendb/ravendb#22410](https://github.com/ravendb/ravendb/discussions/22410)).

The third test in that block, `All sd* devices have read_ahead_kb set to 128`, asserts at least one `sd*` block device exists:

```powershell
$devices = Get-ChildItem "/sys/block/sd*/queue/read_ahead_kb" -ErrorAction SilentlyContinue
$devices | Should -Not -BeNullOrEmpty -Because "there should be at least one sd* block device"
```

This holds on Azure VMs but not on AWS EC2, where EBS volumes present as `nvme*`/`xvd*`. The glob returns empty and the test fails.

## Problem

The first attempt to build `v3.6.0-dev` after the April upstream sync ([#219](https://github.com/grafana/runner-images/pull/219)) failed on **both** architectures:

- Run: [`v3.6.0-dev` Build and Publish · 25060017649](https://github.com/grafana/runner-images/actions/runs/25060017649)
- amd64 job: [build (ubuntu24, amd64)](https://github.com/grafana/runner-images/actions/runs/25060017649/job/73456969138)
- arm64 job: [build (ubuntu24, arm64)](https://github.com/grafana/runner-images/actions/runs/25060017649/job/73456969168)

Failure excerpt from amd64:

```
Failed                : {[-] All sd* devices have read_ahead_kb set to 128}
Tests Passed: 428, Failed: 1, Skipped: 18
Build 'ubuntu24.amazon-ebs.build_image' errored after 35 minutes 51 seconds:
  Script exited with non-zero exit status: 1.
```

## Fix

Skip the test when no `sd*` devices exist instead of failing. When `sd*` devices are present (e.g. on Azure), the value-check still runs.

| Platform | sd* devices | Result |
|---|---|---|
| Azure (kernel >= 6.17 fixed) | yes, value=128 | PASS |
| Azure (broken kernel) | yes, value=4096 | FAIL — real bug still caught |
| AWS | no | SKIP |

## What this does not change

- The udev rule itself (`KERNEL=="sd*", ATTR{queue/read_ahead_kb}="128"` in [`configure-environment.sh`](https://github.com/grafana/runner-images/blob/main/images/ubuntu/scripts/build/configure-environment.sh#L62-L65)) is untouched. Remains a no-op on AWS (no `sd*` devices to match) but installed for any future platform that does present `sd*`.
- The first two tests in the `Describe` block (rule file exists, rule contents correct) are unchanged and still run.

## Verification

PR-level CI does not run the full Packer build. Verification path: merge → retag `v3.6.0-dev` on the new commit → watch the Packer build in [`tag-build-and-publish.yml`](https://github.com/grafana/runner-images/blob/main/.github/workflows/tag-build-and-publish.yml) complete.

## Follow-up

Worth proposing the same change to `actions/runner-images` upstream so other AWS-based forks/users don't hit the same failure. Filing as separate follow-up.